### PR TITLE
Fix install script bugs around handling ipv6 addresses

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -34,13 +34,13 @@ if [ -w /host/etc/cni/net.d ]; then
   cni_spec=$(echo ${CNI_SPEC_TEMPLATE:-} | sed -e "s#@ipv4Subnet#[{\"subnet\": ${ipv4_subnet:-}}]#g")
 
   if [ "$ENABLE_PRIVATE_IPV6_ACCESS" = true ]; then
-    node_ipv6_addr=$(curl -s -k --fail "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/?recursive=true" -H "Metadata-Flavor: Google" | jq '.ipv6s[0]') ||:
+    node_ipv6_addr=$(curl -s -k --fail "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/?recursive=true" -H "Metadata-Flavor: Google" | jq -r '.ipv6s[0]' ) ||:
 
-    if [ -n "${node_ipv6_addr:-}" ]; then
+    if [ -n "${node_ipv6_addr:-}" ] && [ "${node_ipv6_addr}" != "null" ]; then
       echo "Found IPV6 address assignment ${node_ipv6_addr:-}."
-      cni_spec=$(echo ${cni_spec:-} | sed -e
+      cni_spec=$(echo ${cni_spec:-} | sed -e \
         "s#@ipv6SubnetOptional#, [{\"subnet\": \"${node_ipv6_addr:-}/112\"}]#g; 
-         s#@ipv6RouteOptional#, {\"dst\": \"::/0\"}]#g")
+         s#@ipv6RouteOptional#, {\"dst\": \"::/0\"}#g")
     else
       echo "Found empty IPV6 address assignment. Skipping IPV6 subnet and range configuration."
       cni_spec=$(echo ${cni_spec:-} | \


### PR DESCRIPTION
1. Remove the extra quotes around the IPV6 address returned from the Nanny
2. Handle the case where the address returned is "null" instead of an empty string
3. Add back the line continuation accidentally removed from a previous merge