### PR TITLE
Add support for generating a Calico CNI Spec

### DIFF
--- a/netd.yaml
+++ b/netd.yaml
@@ -91,6 +91,43 @@ data:
         }
       ]
     }
+  calico_cni_spec_template: |-
+    {
+      "name": "k8s-pod-network",
+      "cniVersion": "0.3.0",
+      "plugins": [
+        {
+        "type": "calico",
+        "log_level": "debug",
+        "datastore_type": "kubernetes",
+        "nodename": "__KUBERNETES_NODE_NAME__",
+        "ipam": {
+          "type": "host-local",
+          "ranges": [
+          [ { "subnet": "usePodCidr" } ]@ipv6SubnetOptional
+          ],
+          "routes": [
+            {"dst": "0.0.0.0/0"}@ipv6RouteOptional
+          ]
+        },
+        "policy": {
+          "type": "k8s",
+          "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+          "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+          "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          },
+          "snat": true
+        }
+      ]
+    }
   cni_spec_name: "10-k8s-ptp.conflist"
   enable_policy_routing: "true"
   enable_masquerade: "true"
@@ -132,6 +169,11 @@ spec:
               configMapKeyRef:
                 name: netd-config
                 key: cni_spec_template
+          - name: CALICO_CNI_SPEC_TEMPLATE
+            valueFrom:
+              configMapKeyRef:
+                name: netd-config
+                key: calico_cni_spec_template
           - name: CNI_SPEC_NAME
             valueFrom:
               configMapKeyRef:

--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -16,8 +16,10 @@
 
 set -u -e
 if [ "${ENABLE_CALICO_NETWORK_POLICY}" == "true" ]; then
-  echo "Calico Network Policy is enabled by ENABLE_CALICO_NETWORK_POLICY. Disabling CNI Spec generation."
-  exit 0
+  echo "Calico Network Policy is enabled by ENABLE_CALICO_NETWORK_POLICY. Generating Calico CNI spec."
+  cni_spec=${CALICO_CNI_SPEC_TEMPLATE}
+else
+  cni_spec=${CNI_SPEC_TEMPLATE}
 fi
 
 
@@ -31,7 +33,7 @@ fi
 
 if [ -w /host/etc/cni/net.d ]; then
   echo "Adding IPV4 subnet range ${ipv4_subnet:-}."
-  cni_spec=$(echo ${CNI_SPEC_TEMPLATE:-} | sed -e "s#@ipv4Subnet#[{\"subnet\": ${ipv4_subnet:-}}]#g")
+  cni_spec=$(echo ${cni_spec:-} | sed -e "s#@ipv4Subnet#[{\"subnet\": ${ipv4_subnet:-}}]#g")
 
   if [ "$ENABLE_PRIVATE_IPV6_ACCESS" == "true" ]; then
     node_ipv6_addr=$(curl -s -k --fail "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/?recursive=true" -H "Metadata-Flavor: Google" | jq -r '.ipv6s[0]' ) ||:


### PR DESCRIPTION
This is only to generate the spec for calico, using the same spec name. Changes to the calico daemonset to use this file instead of generating its own are upcoming.