### PR TITLE
Quick fix to avoid unnecessary CNI spec generation.

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -20,6 +20,9 @@ echo "netd version: @VERSION@"
 
 if [ "${ENABLE_CALICO_NETWORK_POLICY}" == "true" ]; then
   echo "Calico Network Policy is enabled by ENABLE_CALICO_NETWORK_POLICY. Generating Calico CNI spec."
+  # TODO(varunmar): when calico network policy is enabled, generate CNI spec
+  # template in CNI_NETWORK_CONFIG_FILE understood by Calico's install-cni container.
+  exit 0
   cni_spec=${CALICO_CNI_SPEC_TEMPLATE}
 else
   cni_spec=${CNI_SPEC_TEMPLATE}

--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -55,7 +55,7 @@ if [ -w /host/etc/cni/net.d ]; then
         sed -e "s#@ipv6SubnetOptional##g; s#@ipv6RouteOptional##g")
     fi
   else
-    echo "Disabling IPV6 subnet and range configuration. Set ENABLE_PRIVATE_IPV6_ACCESS=true to configure IPV6."
+    echo "Disabling IPV6 subnet and range configuration as ENABLE_PRIVATE_IPV6_ACCESS=false."
     cni_spec=$(echo ${cni_spec:-} | \
       sed -e "s#@ipv6SubnetOptional##g; s#@ipv6RouteOptional##g")
   fi


### PR DESCRIPTION
Instead of rollback #31 completely, here is a temp & quick fix for #43. @varunmar will fix in a follow-up PR. 