### PR TITLE
Fix masquerade bug.

### DIFF
--- a/pkg/config/config_masquerade.go
+++ b/pkg/config/config_masquerade.go
@@ -29,19 +29,6 @@ var MasqueradeConfigSet = Set{
 
 func init() {
 	MasqueradeConfigSet.Configs = []Config{
-
-		IPTablesRuleConfig{
-			IPTablesChainSpec{
-				TableName:      natTable,
-				ChainName:      postRoutingChain,
-				IsDefaultChain: true,
-				IPT:            ipt,
-			},
-			[]IPTablesRuleSpec{
-				[]string{"-m", "comment", "--comment", "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "IP-MASQ"},
-			},
-			ipt,
-		},
 		IPTablesRuleConfig{
 			IPTablesChainSpec{
 				TableName:      natTable,
@@ -55,6 +42,18 @@ func init() {
 				[]string{"-d", "172.16.0.0/12", "-j", "RETURN", "-m", "comment", "--comment", "ip-masq: local traffic is not subject to MASQUERADE"},
 				[]string{"-d", "192.168.0.0/16", "-j", "RETURN", "-m", "comment", "--comment", "ip-masq: local traffic is not subject to MASQUERADE"},
 				[]string{"-j", "MASQUERADE", "-m", "comment", "--comment", "ip-masq: outbound traffic is subject to MASQUERADE (must be last in chain)"},
+			},
+			ipt,
+		},
+		IPTablesRuleConfig{
+			IPTablesChainSpec{
+				TableName:      natTable,
+				ChainName:      postRoutingChain,
+				IsDefaultChain: true,
+				IPT:            ipt,
+			},
+			[]IPTablesRuleSpec{
+				[]string{"-m", "comment", "--comment", "ip-masq: ensure nat POSTROUTING directs all non-LOCAL destination traffic to our custom IP-MASQ chain", "-m", "addrtype", "!", "--dst-type", "LOCAL", "-j", "IP-MASQ"},
 			},
 			ipt,
 		},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -229,13 +229,6 @@ func TestIPTablesRuleConfig(t *testing.T) {
 		t.Error("Ensure should keep IsDefaultChain: true chain.")
 	}
 
-	/*
-		// This is a bug, the chain should contain 2 rule.
-		if len(fakeIPT.iptCache["postRoutingChain"]) != 2 {
-			t.Error("Ensure should keep 2 rule for iptableRule1.")
-		}
-	*/
-
 	iptableRule1.Ensure(false)
 	if len(fakeIPT.iptCache["postRoutingChain"]) != 0 {
 		t.Error("Ensure should keep 0 rule for iptableRule1.")

--- a/pkg/controllers/netconf/network_config_controller.go
+++ b/pkg/controllers/netconf/network_config_controller.go
@@ -59,7 +59,7 @@ func (n *NetworkConfigController) Run(stopCh <-chan struct{}, wg *sync.WaitGroup
 		select {
 		case <-stopCh:
 			return
-		case <-time.After(n.reconcileIntervalSeconds * time.Second):
+		case <-time.After(n.reconcileIntervalSeconds):
 			continue
 		}
 	}


### PR DESCRIPTION
Fix reconcile interval, the reconcileIntervalSeconds is already in 'second' unit,

no need to multiply with time.Second.
Reorder the masquerade rules, so that the IP-MASQ chain exist before
create the rule in nat table.
Remove comments in unittest which is infeasible.