### PR TITLE
Remove echo version logic in install-cni.sh.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@
 .go/
 bin/
 .push-gcr.*
-scripts/install-cni-build.sh

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -19,7 +19,7 @@ MAINTAINER Jing Ai <jinga@google.com>
 RUN apk --update add --no-cache curl iptables jq \
     && rm -rf /var/cache/apk/*
 
-ADD scripts/install-cni-build.sh /install-cni.sh
+ADD scripts/install-cni.sh /install-cni.sh
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 
 ENTRYPOINT ["/ARG_BIN"]

--- a/build/build.sh
+++ b/build/build.sh
@@ -31,8 +31,6 @@ if [ -z "${VERSION}" ]; then
     exit 1
 fi
 
-cat scripts/install-cni.sh | sed "s/@VERSION@/${VERSION}/" > scripts/install-cni-build.sh
-
 export CGO_ENABLED=0
 export GOARCH="${ARCH}"
 

--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -16,8 +16,6 @@
 
 set -u -e
 
-echo "netd version: @VERSION@"
-
 if [ "${ENABLE_CALICO_NETWORK_POLICY}" == "true" ]; then
   echo "Calico Network Policy is enabled by ENABLE_CALICO_NETWORK_POLICY. Generating Calico CNI spec."
   # TODO(varunmar): when calico network policy is enabled, generate CNI spec


### PR DESCRIPTION
Partially rollback https://github.com/GoogleCloudPlatform/netd/commit/fde2a20797ead5b48b7e6c6b97e560d23586e4fa#diff-fec83b7e693a8e104fa9713533e1c054 as install-cni-build.sh is not never removed properly. Anyway, we can infer the version from container image from pod's spec.