### PR TITLE
Enable IPv6 forwarding when Calico CNI is used.

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -52,6 +52,10 @@ if [ "$ENABLE_PRIVATE_IPV6_ACCESS" == "true" ]; then
     cni_spec=$(echo ${cni_spec:-} | sed -e \
       "s#@ipv6SubnetOptional#, [{\"subnet\": \"${node_ipv6_addr:-}/112\"}]#g;
        s#@ipv6RouteOptional#, {\"dst\": \"::/0\"}#g")
+    if [ "${ENABLE_CALICO_NETWORK_POLICY}" == "true" ]; then
+      echo "Enabling IPv6 forwarding..."
+      sysctl -w net.ipv6.conf.all.forwarding=1
+    fi
   else
     echo "No IPv6 address found for nic0. Clearing IPv6 subnet and route..."
     cni_spec=$(echo ${cni_spec:-} | \


### PR DESCRIPTION
It implicitly requires the container to have capability to run node-level sysctl cmds.