### PR TITLE
Install the ip6tables package in the init container along with iptables

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -16,7 +16,7 @@ FROM ARG_FROM
 
 MAINTAINER Jing Ai <jinga@google.com>
 
-RUN apk --update add --no-cache curl iptables jq \
+RUN apk --update add --no-cache curl iptables ip6tables jq \
     && rm -rf /var/cache/apk/*
 
 ADD scripts/install-cni.sh /install-cni.sh


### PR DESCRIPTION
install-cni.sh needs ip6tables, but does not explicitly install it.
Fixes #74 