### PR TITLE
Overide calico network policy config if it didn't install CNI

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -14,6 +14,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# overide calico network policy config if its cni is not installed as expected
+echo "Calico network policy config: " $ENABLE_CALICO_NETWORK_POLICY
+if [[ ${ENABLE_CALICO_NETWORK_POLICY} == "true" ]]; then
+  cni_file=`ls /host/etc/cni/net.d/*calico* 2> /dev/null`
+  WAITED=0
+  while [[ ${cni_file} == ""  && ${WAITED} -lt 120 ]]
+  do
+      echo "calico cni file not found"
+      WAITED=$((WAITED+2))
+      sleep 2
+      cni_file=`ls /host/etc/cni/net.d/*calico* 2> /dev/null`
+  done
+  if [[ $cni_file == "" ]]; then
+    ENABLE_CALICO_NETWORK_POLICY=false
+    echo "Update calico network policy config to " $ENABLE_CALICO_NETWORK_POLICY
+  fi
+fi
+
 set -u -e
 
 # Get CNI spec template if needed.


### PR DESCRIPTION
In some case, calico network policy config is enabled, but calico cni failed to install. 
This patch detects the case and proceed with gke cni.