### PR TITLE
Write generated cni config file atomically

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -183,8 +183,12 @@ else
   echo "Creating CNI spec..."
 fi
 
-cat > "${output_file}.tmp" <<EOF
-${cni_spec:-}
-EOF
-
-mv "${output_file}.tmp" ${output_file}
+# Atomically write CNI spec
+temp_file=$(mktemp ${output_file}.tmp.XXXXXX)
+if [ $? -ne 0 ]; then
+  echo "Failed to create temp file, Exiting (1)..."
+  exit 1
+fi
+trap "rm -f ${temp_file}" EXIT
+echo ${cni_spec:-} > ${temp_file}
+mv ${temp_file} ${output_file}

--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -190,5 +190,7 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 trap "rm -f ${temp_file}" EXIT
-echo ${cni_spec:-} > ${temp_file}
+cat > ${temp_file} <<EOF
+${cni_spec:-}
+EOF
 mv ${temp_file} ${output_file}

--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -183,6 +183,8 @@ else
   echo "Creating CNI spec..."
 fi
 
-cat >${output_file} <<EOF
+cat > "${output_file}.tmp" <<EOF
 ${cni_spec:-}
 EOF
+
+mv "${output_file}.tmp" ${output_file}


### PR DESCRIPTION
This just ensures that the resulting CNI config file is generated then renamed atomically.