### PR TITLE
Use go 1.14 to build netd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ services:
   - docker
 language: go
 go:
-  - 1.8.x
-  - 1.9.x
-  - 1.10.x
-  - master
+  - 1.14.x
 install:
   - go get -u github.com/golang/dep/...
   - dep ensure

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 
 IMAGE := $(REGISTRY)/$(BIN)-$(ARCH)
 
-BUILD_IMAGE ?= golang:1.9-alpine
+BUILD_IMAGE ?= golang:1.14-alpine
 
 # If you want to build all binaries, see the 'all-build' rule.
 # If you want to build all containers, see the 'all-container' rule.
@@ -84,7 +84,6 @@ bin/$(ARCH)/$(BIN): build-dirs
 	@echo "building: $@"
 	@docker run                                                             \
 	    --rm                                                                \
-	    -u $$(id -u):$$(id -g)                                              \
 	    -v "$$(pwd)/.go:/go"                                                \
 	    -v "$$(pwd):/go/src/$(PKG)"                                         \
 	    -v "$$(pwd)/bin/$(ARCH):/go/bin"                                    \
@@ -148,7 +147,6 @@ version:
 test: build-dirs
 	@docker run                                                             \
 	    --rm                                                                \
-	    -u $$(id -u):$$(id -g)                                              \
 	    -v "$$(pwd)/.go:/go"                                                \
 	    -v "$$(pwd):/go/src/$(PKG)"                                         \
 	    -v "$$(pwd)/bin/$(ARCH):/go/bin"                                    \


### PR DESCRIPTION
1.9 has been out of support for a long time. Move to the latest stable
version.