### PR TITLE
Add a container image for installing random dns delay.

### DIFF
--- a/scripts/dns-delay/Dockerfile
+++ b/scripts/dns-delay/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine
+
+MAINTAINER Zihong Zheng <zihongz@google.com>
+
+RUN apk --update add --no-cache iptables iproute2 \
+    && rm -rf /var/cache/apk/*
+
+ADD install-dns-delay.sh /install-dns-delay.sh
+
+ENTRYPOINT ["/install-dns-delay.sh"]

--- a/scripts/dns-delay/Makefile
+++ b/scripts/dns-delay/Makefile
@@ -1,0 +1,29 @@
+# Copyright 2021 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+REGISTRY ?= gcr.io/gke-release-staging
+VERSION ?= 0.0.1
+IMAGE := $(REGISTRY)/install-dns-delay
+
+.PHONY: container
+container:
+	@docker build -t $(IMAGE):$(VERSION) .
+
+.PHONY: push
+push: container
+	@docker push $(IMAGE):$(VERSION)
+
+.PHONY: version
+version:
+	@echo $(VERSION)

--- a/scripts/dns-delay/install-dns-delay.sh
+++ b/scripts/dns-delay/install-dns-delay.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+echo "Force the kernel to re-create the dummy mq scheduler on the default interface."
+sysctl -w net.core.default_qdisc=fq_codel
+tc qdisc del dev "$(route | grep '^default' | grep -o '[^ ]*$')" root 2>/dev/null || true
+tc qdisc add dev "$(route | grep '^default' | grep -o '[^ ]*$')" root handle 0: mq || true
+echo "Waiting for eth0 interface to come up."
+while ! ip link | grep "eth0:" > /dev/null; do sleep 1; done
+tc qdisc del dev eth0 root 2>/dev/null || true
+tc qdisc add dev eth0 root handle 1: prio bands 2 priomap 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1
+tc qdisc add dev eth0 parent 1:2 handle 12: fq_codel
+echo "Injecting a small delay using netem."
+tc qdisc add dev eth0 parent 1:1 handle 11: netem delay 4ms 1ms distribution pareto
+tc filter add dev eth0 protocol all parent 1: prio 1 handle 0x100/0x100 fw flowid 1:1
+echo "Marking DNS traffic using iptables."
+iptables -A POSTROUTING -t mangle -p udp --dport 53 -m string -m u32 --u32 "28 & 0xF8 = 0" --hex-string "|00001C0001|" --algo bm --from 40 -j MARK --set-mark 0x100/0x100 -w
+echo "Setup completed."


### PR DESCRIPTION
This is to mitigate a kernel race condition bug where conntrack may
be droping packets silently if two DNS queries (one for IPv4, one
for IPv6) are sent in parallel.

This is largely based of the workaround suggested on:
https://blog.quentin-machu.fr/2018/06/24/5-15s-dns-lookups-on-kubernetes/

/assign @prameshj @sypakine