### PR TITLE
Update base image to use debian-iptables

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -14,10 +14,10 @@
 
 FROM ARG_FROM
 
-MAINTAINER Jing Ai <jinga@google.com>
+MAINTAINER Zihong Zheng <zihongz@google.com>
 
-RUN apk --update add --no-cache curl iptables ip6tables jq \
-    && rm -rf /var/cache/apk/*
+RUN apt-get -y update
+RUN apt-get -y install curl jq
 ADD scripts/install-cni.sh /install-cni.sh
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 

--- a/Makefile
+++ b/Makefile
@@ -42,19 +42,7 @@ SRC_DIRS := cmd pkg # directories which hold app source (not vendored)
 
 ALL_ARCH := amd64 arm arm64 ppc64le
 
-# Set default base image dynamically for each arch
-ifeq ($(ARCH), amd64)
-    BASE_IMAGE ?= alpine
-endif
-ifeq ($(ARCH), arm)
-    BASE_IMAGE ?= armel/busybox
-endif
-ifeq ($(ARCH), arm64)
-    BASE_IMAGE ?= aarch64/busybox
-endif
-ifeq ($(ARCH), ppc64le)
-    BASE_IMAGE ?= ppc64le/busybox
-endif
+BASE_IMAGE ?= k8s.gcr.io/build-image/debian-iptables-$(ARCH):buster-v1.8.0
 
 IMAGE := $(REGISTRY)/$(BIN)-$(ARCH)
 


### PR DESCRIPTION
During a recent debug session, I found out that the previously added ip rules for DNS traffic (https://github.com/GoogleCloudPlatform/netd/pull/114) don't fully work as expected.

With the current alpine base image, I saw the sport/dport field being omitted:
```
/ # ip rule show
0:      from all lookup local
29999:  from all lookup main
30000:  from all lookup main
30001:  from all fwmark 0x4000/0x4000 lookup main
30002:  from all iif lo lookup main
30003:  from all iif eth0 lookup 1
32766:  from all lookup main
32767:  from all lookup default
```

It is likely the ip rule dependencies is at a lower version in the alpine image. Update to use the debian-iptables image from k8s seems to resolve the problem. Built a test image with the base image swapped I saw:
```
# ip rule show
0:      from all lookup local 
29999:  from all dport 53 lookup main 
30000:  from all sport 53 lookup main 
30001:  from all fwmark 0x4000/0x4000 lookup main 
30002:  from all iif lo lookup main 
30003:  not from all iif eth0 lookup 1 
32766:  from all lookup main 
32767:  from all lookup default
```

/assign @prameshj @sypakine