### PR TITLE
Update dependencies and install-cni script to work with debian-buster

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -17,7 +17,7 @@ FROM ARG_FROM
 MAINTAINER Zihong Zheng <zihongz@google.com>
 
 RUN apt-get -y update
-RUN apt-get -y install curl jq
+RUN apt-get -y install curl jq bash iproute2
 ADD scripts/install-cni.sh /install-cni.sh
 ADD bin/ARG_ARCH/ARG_BIN /ARG_BIN
 

--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Copyright 2018 Google Inc.
 #


### PR DESCRIPTION
The install script uses bash-isms, and requires the use of the "ip" command to find the MTU

Install these dependencies and modify the shebang line to use /bin/bash instead of /bin/sh

