### PR TITLE
Do not use "sh" to run install-cni.sh since it contains bash syntax

### DIFF
--- a/netd.yaml
+++ b/netd.yaml
@@ -148,7 +148,7 @@ spec:
       initContainers:
       - image: gcr.io/google-containers/netd-amd64:latest
         name: install-cni
-        command: ["sh", "/install-cni.sh"]
+        command: ["/install-cni.sh"]
         env:
           - name: CNI_SPEC_TEMPLATE
             valueFrom:


### PR DESCRIPTION
Fixes #119. Not removing bash syntax from `install-cni.sh` for now since it's a larger project.