### PR TITLE
Wait until cilium-cni binary is ready when ENABLE_CILIUM_PLUGIN is set

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -71,6 +71,12 @@ fi
 if [ "${ENABLE_CILIUM_PLUGIN}" == "true" ]
 then
   cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniCiliumPlugin#,{\"type\": \"cilium-cni\"}#g")
+  cilium_bin="/host/home/kubernetes/bin/cilium-cni"
+  while [ ! -f "$cilium_bin" ]
+  do
+    echo "Waiting for $cilium_bin to be ready..."
+    sleep 2
+  done
 else
   cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniCiliumPlugin##g")
 fi

--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -56,23 +56,23 @@ fi
 
 if [ -f "/host/home/kubernetes/bin/gke" ]
 then
-	cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniType#gke#g")
+  cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniType#gke#g")
 else
-	cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniType#ptp#g")
+  cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniType#ptp#g")
 fi
 
 if [ "${ENABLE_BANDWIDTH_PLUGIN}" == "true" ] && [ -f "/host/home/kubernetes/bin/bandwidth" ]
 then
-	cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniBandwidthPlugin#,{\"type\": \"bandwidth\",\"capabilities\": {\"bandwidth\": true}}#g")
+  cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniBandwidthPlugin#,{\"type\": \"bandwidth\",\"capabilities\": {\"bandwidth\": true}}#g")
 else
-	cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniBandwidthPlugin##g")
+  cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniBandwidthPlugin##g")
 fi
 
 if [ "${ENABLE_CILIUM_PLUGIN}" == "true" ]
 then
-        cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniCiliumPlugin#,{\"type\": \"cilium-cni\"}#g")
+  cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniCiliumPlugin#,{\"type\": \"cilium-cni\"}#g")
 else
-        cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniCiliumPlugin##g")
+  cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniCiliumPlugin##g")
 fi
 
 # Fill CNI spec template.

--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -70,6 +70,7 @@ fi
 
 if [ "${ENABLE_CILIUM_PLUGIN}" == "true" ]
 then
+  echo "Adding Cilium plug-in to the CNI config."
   cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniCiliumPlugin#,{\"type\": \"cilium-cni\"}#g")
   cilium_bin="/host/home/kubernetes/bin/cilium-cni"
   while [ ! -f "$cilium_bin" ]
@@ -77,7 +78,9 @@ then
     echo "Waiting for $cilium_bin to be ready..."
     sleep 2
   done
+  echo "$cilium_bin found."
 else
+  echo "Not using Cilium plug-in."
   cni_spec=$(echo ${cni_spec:-} | sed -e "s#@cniCiliumPlugin##g")
 fi
 


### PR DESCRIPTION
I'm avoiding bash-specific syntax ([[ ]] instead of [ ]) due to #119 (even if I'm fixing the configuration file to use bash instead of sh, I'm not sure about the direction of the next step, so better to be safe here).