### PR TITLE
Add pod_ip_metrics collector to netd

### DIFF
--- a/pkg/metrics/collector/collector.go
+++ b/pkg/metrics/collector/collector.go
@@ -65,8 +65,9 @@ type NodeCollector struct {
 
 // NewNodeCollector creates a new NodeCollector with given enabledCollectors (a list
 // of enabled collectors name) and a list of prometheus collector
-func NewNodeCollector(enabledCollectors []string, proc string) (*NodeCollector, []prometheus.Collector, error) {
+func NewNodeCollector(enabledCollectors []string, proc string, stack string) (*NodeCollector, []prometheus.Collector, error) {
 	procPath = proc
+	stackType = stack
 	collectors := make(map[string]Collector)
 	for _, name := range enabledCollectors {
 		createFunc, exist := factories[name]

--- a/pkg/metrics/collector/helper.go
+++ b/pkg/metrics/collector/helper.go
@@ -24,6 +24,7 @@ import (
 )
 
 var procPath string
+var stackType string
 
 // readUintFromFile reads a uint from file given by path. The file is supposed to only contain a single uint
 // in base 10. Otherwise, an error will be returned.

--- a/pkg/metrics/collector/pod_ip_metrics.go
+++ b/pkg/metrics/collector/pod_ip_metrics.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2022 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type ipFamily int
+
+const (
+	gkePodNetworkDir = "/host/var/lib/cni/networks/gke-pod-network"
+	ipv4 ipFamily = iota
+	ipv6 = 1
+	dual = 2
+	dualStack = "IPV4_IPV6"
+)
+
+var (
+	usedIpv4AddrCountDesc = prometheus.NewDesc(
+		"used_ipv4_addr_count",
+		"Indicates how many IPv4 addresses are in use.",
+		nil, nil,
+	)
+	usedIpv6AddrCountDesc = prometheus.NewDesc(
+		"used_ipv6_addr_count",
+		"Indicates how many IPv6 addresses are in use.",
+		nil, nil,
+	)
+	dualStackCountDesc = prometheus.NewDesc(
+		"dual_stack_count",
+		"Indicates how many pods have dual stack IP addresses.",
+		nil, nil,
+	)
+	dualStackErrorCountDesc = prometheus.NewDesc(
+		"dual_stack_error_count",
+		"Indicates how many pods did not get dual stack IPs erroneously.",
+		nil, nil,
+	)
+	duplicateIpCountDesc = prometheus.NewDesc(
+		"duplicate_ip_count",
+		"Indicates how many pods had more than one IP per family.",
+		nil, nil,
+	)
+)
+
+type podIpMetricsCollector struct {
+	usedIpv4AddrCount uint64
+	usedIpv6AddrCount uint64
+	dualStackCount uint64
+	dualStackErrorCount uint64
+	duplicateIpCount uint64
+}
+
+func (ip ipFamily) String() string {
+	return [...]string{"IPV4", "IPV6", "IPV4_IPV6"}[ip]
+}
+
+func init() {
+	registerCollector("pod_ip_metrics", NewPodIpMetricsCollector)
+}
+
+// NewPodIpMetricsCollector returns a new Collector exposing pod IP allocation
+// stats.
+func NewPodIpMetricsCollector() (Collector, error) {
+	return &podIpMetricsCollector{}, nil
+}
+
+func readLine(path string) (string, error) {
+	buf, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+
+	defer func() {
+		if err = buf.Close(); err != nil {
+			glog.Errorf("Error closing file %s: %s", path, err)
+		}
+	}()
+
+	s := bufio.NewScanner(buf)
+	s.Scan()
+	return s.Text(), s.Err()
+}
+
+func (c *podIpMetricsCollector) listIpAddresses(dir string) error {
+	f, err := os.Open(dir)
+	if err != nil {
+		glog.Errorf("Error opening directory %s, %v", dir, err)
+		return err
+	}
+	files, err := f.Readdir(0)
+	if err != nil {
+		glog.Errorf("Error while reading files in directory %v", err)
+		return err
+	}
+
+	podMap := make(map[string]ipFamily)
+	var ipv4Count, ipv6Count, dupIpCount, dualCount, dualErrCount uint64
+	for _, v := range files {
+		if ip := net.ParseIP(v.Name()); ip == nil {
+			// This isn't an IP address file
+			continue
+		}
+		var family ipFamily
+		if strings.Contains(v.Name(), ":") {
+			ipv6Count++
+			family = ipv6
+		} else {
+			ipv4Count++
+			family = ipv4
+		}
+		// Update the map and track IP families only for dual stack clusters
+		fileName := fmt.Sprintf("%s/%s", dir, v.Name())
+		podId, err := readLine(fileName)
+		if err != nil {
+			glog.Errorf("Error reading file %s: %v", fileName, err)
+			continue
+		}
+		f, ok := podMap[podId]
+		if !ok {
+			podMap[podId] = family
+		} else if (f == ipv4 && family == ipv6) || (f == ipv6 && family == ipv4) {
+			podMap[podId] = dual
+		} else {
+			dupIpCount++
+		}
+	}
+	if stackType == dualStack {
+		for _, family := range podMap {
+			if family == dual {
+				dualCount++
+			} else {
+				dualErrCount++
+			}
+		}
+	}
+	c.usedIpv4AddrCount = ipv4Count
+	c.usedIpv6AddrCount = ipv6Count
+	c.dualStackCount = dualCount
+	c.dualStackErrorCount = dualErrCount
+	c.duplicateIpCount = dupIpCount
+	return nil
+}
+
+func (c *podIpMetricsCollector) Update(ch chan<- prometheus.Metric) error {
+	if err := c.listIpAddresses(gkePodNetworkDir); err != nil {
+		glog.Errorf("ListIpAddresses returned error: %v", err)
+		return nil
+	}
+	ch <- prometheus.MustNewConstMetric(usedIpv4AddrCountDesc, prometheus.GaugeValue, float64(c.usedIpv4AddrCount))
+	ch <- prometheus.MustNewConstMetric(usedIpv6AddrCountDesc, prometheus.GaugeValue, float64(c.usedIpv6AddrCount))
+	ch <- prometheus.MustNewConstMetric(dualStackCountDesc, prometheus.GaugeValue, float64(c.dualStackCount))
+	ch <- prometheus.MustNewConstMetric(dualStackErrorCountDesc, prometheus.GaugeValue, float64(c.dualStackErrorCount))
+	ch <- prometheus.MustNewConstMetric(duplicateIpCountDesc, prometheus.GaugeValue, float64(c.duplicateIpCount))
+
+	return nil
+}

--- a/pkg/metrics/collector/pod_ip_metrics_test.go
+++ b/pkg/metrics/collector/pod_ip_metrics_test.go
@@ -1,0 +1,132 @@
+package collector
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func mustCreateFile(t *testing.T, dir, name, content string) {
+	path := dir + "/" + name
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("Error creating file path %s: %v", path, err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatalf("Error writing to file %s: %v", path, err)
+	}
+}
+
+func mustCreateIpAddrDir(t *testing.T, dir string) string {
+	tempDir, err := ioutil.TempDir("", dir)
+	if err != nil {
+		t.Fatalf("Error creating dir %s: %v", dir, err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	mustCreateFile(t, tempDir, "lock", "")
+	mustCreateFile(t, tempDir, "last_allocated_ip.0", "10.0.0.1")
+	return tempDir
+}
+
+func TestListIpAddresses(t *testing.T) {
+	// dir1 has 2 IPv4 addresses and 2 IPv6 addresses for dual stack pods
+	dir1 := mustCreateIpAddrDir(t, "dir1")
+	mustCreateFile(t, dir1, "10.0.0.1", "hash1")
+	mustCreateFile(t, dir1, "10.0.0.2", "hash2")
+	mustCreateFile(t, dir1, "2600:1900::1", "hash1")
+	mustCreateFile(t, dir1, "2600:1900::2", "hash2")
+
+	// dir2 has 2 IPv4 addresses and 2 IPv6 addresses but only one real dual stack
+	// pod
+	dir2 := mustCreateIpAddrDir(t, "dir2")
+	mustCreateFile(t, dir2, "10.0.0.1", "hash1")
+	mustCreateFile(t, dir2, "10.0.0.2", "hash2")
+	mustCreateFile(t, dir2, "2600:1900::1", "hash1")
+	mustCreateFile(t, dir2, "2600:1900::3", "hash3")
+
+	// dir3 has 2 IPv4 and IPv6 addresses allocated for the same pod
+	dir3 := mustCreateIpAddrDir(t, "dir3")
+	mustCreateFile(t, dir3, "10.0.0.1", "hash1")
+	mustCreateFile(t, dir3, "10.0.0.2", "hash1")
+	mustCreateFile(t, dir3, "2600:1900::1", "hash1")
+	mustCreateFile(t, dir3, "2600:1900::2", "hash1")
+
+	for _, tc := range []struct {
+		desc string
+		dir string
+		stackType string
+		wantUsedIpv4Count uint64
+		wantUsedIpv6Count uint64
+		wantDualStackCount uint64
+		wantDualStackErrCount uint64
+		wantDuplicateIpCount uint64
+		wantErr bool
+	} {
+		{
+			desc: "bad directory",
+			dir: "bogus",
+			stackType: "IPV4",
+			wantErr: true,
+		},
+		{
+			desc: "dir1 with 2 IPv4 and 2 IPv6 addresses. Single stack",
+			dir: dir1,
+			stackType: "IPV4",
+			wantUsedIpv4Count: 2,
+			wantUsedIpv6Count: 2,
+		},
+		{
+			desc: "dir1 with 2 IPv4 and 2 IPv6 addresses. dual stack",
+			dir: dir1,
+			stackType: "IPV4_IPV6",
+			wantUsedIpv4Count: 2,
+			wantUsedIpv6Count: 2,
+			wantDualStackCount: 2,
+		},
+		{
+			desc: "dir2 with dual stack errors",
+			dir: dir2,
+			stackType: "IPV4_IPV6",
+			wantUsedIpv4Count: 2,
+			wantUsedIpv6Count: 2,
+			wantDualStackCount: 1,
+			wantDualStackErrCount: 2,
+		},
+		{
+			desc: "dir2 with dual stack and dup IPs",
+			dir: dir3,
+			stackType: "IPV4_IPV6",
+			wantUsedIpv4Count: 2,
+			wantUsedIpv6Count: 2,
+			wantDualStackCount: 1,
+			wantDuplicateIpCount: 2,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			stackType = tc.stackType
+			mc := podIpMetricsCollector{}
+			err := mc.listIpAddresses(tc.dir)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Errorf("Expected error %t, got error: %v", tc.wantErr, err)
+				return
+			}
+			if mc.usedIpv4AddrCount != tc.wantUsedIpv4Count {
+				t.Errorf("usedIpv4AddrCount. want: %d, got %d", tc.wantUsedIpv4Count, mc.usedIpv4AddrCount)
+			}
+			if mc.usedIpv6AddrCount != tc.wantUsedIpv6Count {
+				t.Errorf("usedIpv6AddrCount. want: %d, got %d", tc.wantUsedIpv6Count, mc.usedIpv6AddrCount)
+			}
+			if mc.dualStackCount != tc.wantDualStackCount {
+				t.Errorf("dualStackCount. want: %d, got %d", tc.wantDualStackCount, mc.dualStackCount)
+			}
+			if mc.dualStackErrorCount != tc.wantDualStackErrCount {
+				t.Errorf("dualStackErrorCount. want: %d, got %d", tc.wantDualStackErrCount, mc.dualStackErrorCount)
+			}
+			if mc.duplicateIpCount != tc.wantDuplicateIpCount {
+				t.Errorf("duplicateIpCount. want: %d, got %d", tc.wantDuplicateIpCount, mc.duplicateIpCount)
+			}
+		})
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -32,13 +32,15 @@ var mcfg struct {
 	enabledCollectors string
 	listenAddress     string
 	procPath          string
+	stackType					string
 }
 
 func init() {
 	flag.StringVar(&mcfg.enabledCollectors, "metrics-collectors", "",
-		"Enable given metrics collectors (options: conntrack,socket,kernel_metrics,netlink_metrics).")
+		"Enable given metrics collectors (options: conntrack,socket,kernel_metrics,netlink_metrics,pod_ip_metrics).")
 	flag.StringVar(&mcfg.listenAddress, "metrics-address", "localhost:10231", "Address on which to expose metrics.")
 	flag.StringVar(&mcfg.procPath, "metrics-proc-path", "/proc", "Proc directory to read metrics.")
+	flag.StringVar(&mcfg.stackType, "stack-type", "IPV4", "Stack type.")
 }
 
 // StartCollector starts the metrics collector with mcfg configured from input flag
@@ -48,7 +50,7 @@ func StartCollector() error {
 		return nil
 	}
 	enabledCollectors := strings.Split(mcfg.enabledCollectors, ",")
-	nc, pc, err := collector.NewNodeCollector(enabledCollectors, mcfg.procPath)
+	nc, pc, err := collector.NewNodeCollector(enabledCollectors, mcfg.procPath, mcfg.stackType)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This new module emits metrics for pod IP allocation by examining the gke-pod-network directory