### PR TITLE
Fix build.sh for netd-init to use $GOPATH

### DIFF
--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -34,7 +34,7 @@ fi
 BUILD="${VERSION}-${OS}-${ARCH}"
 
 SRC=install-cni.sh
-DST=${HOME}/go/bin/netd-init
+DST=${GOPATH}/bin/netd-init
 
 rm -rf "${DST}"
 mkdir -p "$(dirname "${DST}")"


### PR DESCRIPTION
Try a different path spec. I don't know why it worked on my dev env but not on Louhi.

/assign @MrHohn 