### PR TITLE
Add .buildx-initialized as a prerequisite of container-%

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -102,7 +102,7 @@ build-%:
 	    GOOS=$(firstword $(subst _, ,$*)) \
 	    GOARCH=$(lastword $(subst _, ,$*))
 
-container-%: $(THIRD_PARTY_SOURCE_FILES)
+container-%: .buildx-initialized $(THIRD_PARTY_SOURCE_FILES)
 	$(MAKE) container                     \
 	    --no-print-directory              \
 	    GOOS=$(firstword $(subst _, ,$*)) \


### PR DESCRIPTION
This is similar to GoogleCloudPlatform/netd@f8eb709 to make sure that
buildx is ready before running make for each platform in parallel.