### PR TITLE
Replace route command with reading from /proc in install-cni.sh

### DIFF
--- a/scripts/shell-test.sh
+++ b/scripts/shell-test.sh
@@ -61,7 +61,7 @@ run_test jq_cmd
 [[ "$(echo '{"test":"value"}' | jq .test)" == '"value"' ]] && pass || fail
 
 run_test default_nic_mtu
-[[ -f "/sys/class/net/$(route -n | grep -E '^0\.0\.0\.0\s+\S+\s+0\.0\.0\.0' | grep -oE '\S+$')/mtu" ]] && pass || fail
+[[ -f "/sys/class/net/$(grep -E '^\S+\s+00000000\s+\S+\s+\S+\s+\S+\s+\S+\s+\S+\s+00000000\s+' /proc/net/route | grep -oE '^\S+')/mtu" ]] && pass || fail
 
 run_test mktemp_cmd
 [[ -f "$(mktemp /tmp.XXXXXX)" ]] && pass || fail


### PR DESCRIPTION
This removes the use of `route` command from netd-init.

/assign @MrHohn 