### PR TITLE
Make changes to `build` GitHub workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,6 @@
 name: Build for all architectures
 
-on: [ push, pull_request ]
+on: [ push ]
 
 jobs:
   build:

--- a/.github/workflows/nativebuild.yaml
+++ b/.github/workflows/nativebuild.yaml
@@ -4,9 +4,13 @@ on: [ push, pull_request ]
 
 jobs:
   nativebuild:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ "1.18", "1.19" ]
+        platform: [ "ubuntu-latest" ]
+    runs-on: ${{ matrix.platform }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
     - name: Build containers
-      run: make -f Makefile.all container
+      run: make -f Makefile.all container GO_VERSION=${{ matrix.go-version }}


### PR DESCRIPTION
* Change `nativebuild` to run on a matrix of Go versions. This is the fastest build so we afford to run a couple more tests here. The current code is known to fail building in Go 1.17.
* Change (full) `build` to run on push only (not pull requests, i.e. just at merge) because it's too slow.

/assign @MrHohn 