### PR TITLE
Separate the src_valid_mark sysctl bit from the default configs and add a flag for it.

### DIFF
--- a/cmd/netd/main.go
+++ b/cmd/netd/main.go
@@ -42,7 +42,7 @@ func main() {
 	glog.Infof("netd args: %v", strings.Join(os.Args, " "))
 
 	nc := netconf.NewNetworkConfigController(config.EnablePolicyRouting, config.EnableMasquerade,
-		config.ExcludeDNS, config.ReconcileInterval)
+		config.EnableSourceValidMark, config.ExcludeDNS, config.ReconcileInterval)
 
 	stopCh := make(chan struct{})
 

--- a/pkg/config/config_policy_routing.go
+++ b/pkg/config/config_policy_routing.go
@@ -102,12 +102,6 @@ func init() {
 			DefaultValue: "1",
 			SysctlFunc:   sysctl.Sysctl,
 		},
-		SysctlConfig{
-			Key:          sysctlSrcValidMark,
-			Value:        "1",
-			DefaultValue: "0",
-			SysctlFunc:   sysctl.Sysctl,
-		},
 		IPTablesRuleConfig{
 			IPTablesChainSpec{
 				TableName:      tableMangle,
@@ -221,6 +215,13 @@ func init() {
 			RuleList: netlink.RuleList,
 		},
 	}
+}
+
+var SourceValidMarkConfig = SysctlConfig{
+	Key:          sysctlSrcValidMark,
+	Value:        "1",
+	DefaultValue: "0",
+	SysctlFunc:   sysctl.Sysctl,
 }
 
 var ExcludeDNSIPRuleConfigs = []Config{

--- a/pkg/controllers/netconf/network_config_controller.go
+++ b/pkg/controllers/netconf/network_config_controller.go
@@ -33,13 +33,17 @@ type NetworkConfigController struct {
 }
 
 // NewNetworkConfigController creates a new NetworkConfigController
-func NewNetworkConfigController(enablePolicyRouting, enableMasquerade, excludeDNS bool, reconcileInterval time.Duration) *NetworkConfigController {
+func NewNetworkConfigController(enablePolicyRouting, enableMasquerade, enableSourceValidMark, excludeDNS bool,
+	reconcileInterval time.Duration) *NetworkConfigController {
 	var configSet []*config.Set
 
 	configSet = append(configSet, &config.PolicyRoutingConfigSet)
 
 	if enablePolicyRouting {
 		config.PolicyRoutingConfigSet.Enabled = true
+	}
+	if enableSourceValidMark {
+		configSet[0].Configs = append(configSet[0].Configs, config.SourceValidMarkConfig)
 	}
 	if excludeDNS {
 		configSet[0].Configs = append(configSet[0].Configs, config.ExcludeDNSIPRuleConfigs...)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -24,10 +24,11 @@ import (
 
 // NetdConfig defines the netd config
 type NetdConfig struct {
-	EnablePolicyRouting bool
-	ExcludeDNS          bool
-	EnableMasquerade    bool
-	ReconcileInterval   time.Duration
+	EnablePolicyRouting   bool
+	EnableSourceValidMark bool
+	ExcludeDNS            bool
+	EnableMasquerade      bool
+	ReconcileInterval     time.Duration
 }
 
 // NewNetdConfig creates a new netd config
@@ -39,6 +40,8 @@ func NewNetdConfig() *NetdConfig {
 func (nc *NetdConfig) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&nc.EnablePolicyRouting, "enable-policy-routing", false,
 		"Enable policy routing.")
+	fs.BoolVar(&nc.EnableSourceValidMark, "enable-source-valid-mark", true,
+		"Whether to enable the src_valid_mark sysctl bit for policy routing.")
 	fs.BoolVar(&nc.ExcludeDNS, "exclude-dns", false,
 		"Whether to exclude DNS traffic from policy routing.")
 	fs.BoolVar(&nc.EnableMasquerade, "enable-masquerade", true,


### PR DESCRIPTION
The `src_valid_mark` sysctl bit may interfere with some linux networking features (e.g. [transparent proxying](https://www.kernel.org/doc/html/latest/networking/ip-sysctl.html)) and is not always required when enabling the hairpin traffic path (pod -> service clusterIP -> pod_itself).

This PR adds a flag to enable/disable this sysctl bit so we will have more flexibility when deploying netd.

/assign @jingyuanliang @rahulkjoshi