### PR TITLE
remove confusing comment with typos

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -192,8 +192,6 @@ if [ "${ENABLE_PRIVATE_IPV6_ACCESS:-}" == "true" ] || [ "$ENABLE_IPV6" == "true"
     # Ensure the IPv6 firewall rules are as expected.
     # These rules mirror the IPv4 rules installed by kubernetes/cluster/gce/gci/configure-helper.sh
     
-    # We need to add rules to accept all TCP/UDP/ICMP/SCTP packets or HostNetwork pods, NodePort Services
-    # and Healtcheck probes between others will not work.
     if ip6tables -w -L INPUT | grep "Chain INPUT (policy DROP)" > /dev/null; then
       echo "Add rules to accept all inbound TCP/UDP/ICMP/SCTP IPv6 packets"
       ip6tables -A INPUT -w -p tcp -j ACCEPT


### PR DESCRIPTION
the typos, and also the NodePorts may not need iptables accept on INPUT, the previous comment references 

>     # These rules mirror the IPv4 rules installed by kubernetes/cluster/gce/gci/configure-helper.sh

that is exactly what happens