### PR TITLE
Change pod MTU to match cilium_wg0 MTU, if present

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -224,7 +224,11 @@ fi
 default_nic=$(route -n | grep -E '^0\.0\.0\.0\s+\S+\s+0\.0\.0\.0' | grep -oE '\S+$')
 
 # Set mtu
-if [ -f "/sys/class/net/$default_nic/mtu" ]; then
+if [ -f "/sys/class/net/cilium_wg0/mtu" ]; then
+  MTU=$(cat "/sys/class/net/cilium_wg0/mtu")
+  cni_spec=${cni_spec//@mtu/$MTU}
+  echo "Set the default mtu to $MTU, inherited from dev cilium_wg0"
+elif [ -f "/sys/class/net/$default_nic/mtu" ]; then
   MTU=$(cat "/sys/class/net/$default_nic/mtu")
   cni_spec=${cni_spec//@mtu/$MTU}
   echo "Set the default mtu to $MTU, inherited from dev $default_nic"


### PR DESCRIPTION
The cilium_wg0 interface is created on the GKE node if node2node encryption is enabled. This has a lower MTU as compared to eth0 inorder to accomodate encryption headers. Hence we need to reduce MTU for pod interfaces to avoid fragmentation.