### PR TITLE
Send "expected" errors from cilium_ready in install-cni.sh to stdout

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -27,7 +27,9 @@ cilium_ready() {
   # Cilium's CNI installer doesn't do atomic write (write to temporary file then move).
   echo "(errors are expected during bootstrap; will retry until success)"
   # The command producing exit status must be the last command here.
-  CNI_COMMAND=VERSION /host/home/kubernetes/bin/cilium-cni
+  # Send errors to stdout since they're "expected" errors.
+  # This redirection doesn't affect exit status after execution.
+  CNI_COMMAND=VERSION /host/home/kubernetes/bin/cilium-cni 2>&1
 }
 
 # inotify callback


### PR DESCRIPTION
Don't let them go to stderr and show up in logging as errors causing unexpected and unrelated support requests sent to us.

/assign @MrHohn 