### PR TITLE
Completely remove --enable-masquerade flag

### DIFF
--- a/cmd/netd/main.go
+++ b/cmd/netd/main.go
@@ -42,8 +42,7 @@ func main() {
 		glog.Infof("FLAG: --%s=%q", f.Name, f.Value)
 	})
 
-	nc := netconf.NewNetworkConfigController(config.EnablePolicyRouting, config.EnableMasquerade,
-		config.EnableSourceValidMark, config.ExcludeDNS, config.ReconcileInterval)
+	nc := netconf.NewNetworkConfigController(config.EnablePolicyRouting, config.EnableSourceValidMark, config.ExcludeDNS, config.ReconcileInterval)
 
 	stopCh := make(chan struct{})
 

--- a/pkg/controllers/netconf/network_config_controller.go
+++ b/pkg/controllers/netconf/network_config_controller.go
@@ -33,8 +33,7 @@ type NetworkConfigController struct {
 }
 
 // NewNetworkConfigController creates a new NetworkConfigController
-func NewNetworkConfigController(enablePolicyRouting, enableMasquerade, enableSourceValidMark, excludeDNS bool,
-	reconcileInterval time.Duration) *NetworkConfigController {
+func NewNetworkConfigController(enablePolicyRouting, enableSourceValidMark, excludeDNS bool, reconcileInterval time.Duration) *NetworkConfigController {
 	var configSet []*config.Set
 
 	configSet = append(configSet, &config.PolicyRoutingConfigSet)

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -27,7 +27,6 @@ type NetdConfig struct {
 	EnablePolicyRouting   bool
 	EnableSourceValidMark bool
 	ExcludeDNS            bool
-	EnableMasquerade      bool
 	ReconcileInterval     time.Duration
 }
 
@@ -44,8 +43,6 @@ func (nc *NetdConfig) AddFlags(fs *pflag.FlagSet) {
 		"Whether to enable the src_valid_mark sysctl bit for policy routing.")
 	fs.BoolVar(&nc.ExcludeDNS, "exclude-dns", false,
 		"Whether to exclude DNS traffic from policy routing.")
-	fs.BoolVar(&nc.EnableMasquerade, "enable-masquerade", true,
-		"[Deprecated]Enable masquerade.")
 	fs.DurationVar(&nc.ReconcileInterval, "reconcile-interval-seconds", 10*time.Second,
 		"Reconcile interval in seconds.")
 }


### PR DESCRIPTION
This flag has been a no-op since 344d9f4837f56b88ea4fe2fd3777a177fa2522da and the existence of this flag adds confusion despite marked as deprecated.