### PR TITLE
Fix typo in kernel metrics

### DIFF
--- a/pkg/metrics/collector/kernel_metrics.go
+++ b/pkg/metrics/collector/kernel_metrics.go
@@ -37,8 +37,8 @@ const (
 	tcpSegsOut     = "OutSegs"     // Total tcp segments out
 	tcpSegsRetrans = "RetransSegs" // Total tcp segments retransmitted
 	// Got from netstat
-	tcpTimeoutRehash   = "TcpTimeoutRehash"      // Total tcp timeout rehash
-	tcpDuplicateRehash = "TcpDupliateDataRehash" // Total tcp duplicates rehashed
+	tcpTimeoutRehash   = "TcpTimeoutRehash"       // Total tcp timeout rehash
+	tcpDuplicateRehash = "TcpDuplicateDataRehash" // Total tcp duplicates rehashed
 )
 
 var (


### PR DESCRIPTION
I think this was done because there was a typo in netstat at the time but it has since been fixed.