### PR TITLE
Remove `set -o pipefail` from scripts/build/build.sh

### DIFF
--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -16,7 +16,6 @@
 
 set -o errexit
 set -o nounset
-set -o pipefail
 
 if [ -z "${OS:-}" ]; then
     echo "OS must be set"


### PR DESCRIPTION
For the same rationale as thockin/go-build-template#106.

/assign @MrHohn 