### PR TITLE
Add an extra delay CILIUM_WATCHDOG_FAST_START_WAIT

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -313,10 +313,12 @@ fi
 echo "Running CNI watchdog to watch Cilium and manage CNI config at '${output_file}' with content: $(jq -c . <<<"${cni_spec}")"
 cilium_watchdog_success_wait=${CILIUM_WATCHDOG_SUCCESS_WAIT:-300}
 cilium_watchdog_failure_retry=${CILIUM_WATCHDOG_FAILURE_RETRY:-60}
+cilium_watchdog_fast_start_wait=${CILIUM_WATCHDOG_FAST_START_WAIT:-60}
 
 if [[ -n "${CILIUM_FAST_START_NAMESPACES:-}" ]]; then
-  echo "Cilium has fast-start; writing CNI config upfront then start to check Cilium health."
+  echo "Cilium has fast-start; writing CNI config upfront then wait for ${cilium_watchdog_fast_start_wait}s and start to check Cilium health."
   write_file "${output_file}" "${cni_spec}"
+  sleep "${cilium_watchdog_fast_start_wait}"s
 fi
 
 while true; do

--- a/scripts/testcase/testcase-watchdog-cilium-faststart-unhealthy.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-faststart-unhealthy.sh
@@ -57,6 +57,13 @@ function before_test() {
   }
   export -f curl
 
+  # shellcheck disable=SC2317
+  function sleep() {
+    echo "[MOCK called] sleep $*"
+    echo "[MOCK] this test expects a delay during fast start."
+  }
+  export -f sleep
+
 }
 
 function verify() {

--- a/scripts/testcase/testcase-watchdog-cilium-faststart-wait.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-faststart-wait.sh
@@ -13,7 +13,7 @@ export RUN_CNI_WATCHDOG=true
 CNI_SPEC_TEMPLATE=$(cat testdata/spec-template.json)
 export CNI_SPEC_TEMPLATE
 
-export TEST_WANT_EXIT_CODE=24
+export TEST_WANT_EXIT_CODE=${TEST_EXIT_CODE_SLEEP}
 
 function before_test() {
 
@@ -43,9 +43,9 @@ function before_test() {
               }'
         ;;
       *http://localhost:63197/*)
-        # With fast-start enabled, CNI config should have been written
-        # at the first Cilium health check attempt.
-        exit "${TEST_WANT_EXIT_CODE}"
+        # This test shouldn't reach this. It should hit an exit-by-sleep
+        # earlier, at which time the CNI config must have been written.
+        exit 1
         ;;
       *)
         #unsupported
@@ -53,13 +53,6 @@ function before_test() {
     esac
   }
   export -f curl
-
-  # shellcheck disable=SC2317
-  function sleep() {
-    echo "[MOCK called] sleep $*"
-    echo "[MOCK] this test expects a delay during fast start."
-  }
-  export -f sleep
 
 }
 


### PR DESCRIPTION
To allow for more time for Cilium to start, before a fast-start node is marked unready after being ready.

/assign @pravk03 