### PR TITLE
Fix lint failures caused by koalaman/shellcheck@4f81dbe

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -21,7 +21,7 @@ calico_ready() {
   compgen -G "/host/etc/cni/net.d/*calico*.conflist"
 }
 
-# shellcheck disable=SC2317 # when called with $1=cni_ready
+# shellcheck disable=SC2317,SC2329 # when called with $1=cni_ready
 cni_ready() {
   local -r cni_bin="$1"
   echo "Running '/host/home/kubernetes/bin/${cni_bin}' with CNI_COMMAND=VERSION"

--- a/scripts/test-install-cni.sh
+++ b/scripts/test-install-cni.sh
@@ -3,24 +3,28 @@
 function init_default_cmd_mocks() {
   shopt -s expand_aliases
 
+  # shellcheck disable=SC2329
   function iptables() {
     # shellcheck disable=SC2317
     echo "[MOCK called] iptables $*"
   }
   export -f iptables
 
+  # shellcheck disable=SC2329
   function ip6tables() {
     # shellcheck disable=SC2317
     echo "[MOCK called] ip6tables $*"
   }
   export -f ip6tables
 
+  # shellcheck disable=SC2329
   function inotify() {
     # shellcheck disable=SC2317
     echo "[MOCK called] inotify $*"
   }
   export -f inotify
 
+  # shellcheck disable=SC2329
   function route() {
     # shellcheck disable=SC2317
     echo 'Kernel IP routing table
@@ -29,19 +33,21 @@ Destination     Gateway         Genmask         Flags Metric Ref    Use Iface
   }
   export -f route
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     echo "[MOCK called] curl $*"
   }
   export -f curl
 
+  # shellcheck disable=SC2329
   function timeout() {
     # shellcheck disable=SC2317
     echo "[MOCK called] timeout $*"
   }
   export -f timeout
 
-  # shellcheck disable=SC2317
+  # shellcheck disable=SC2317,SC2329
   function sleep() {
     echo "[MOCK called] sleep $*"
     echo "[MOCK] sleep shouldn't be called during normal execution; exiting with ${TEST_EXIT_CODE_SLEEP} as a signal."

--- a/scripts/testcase/testcase-basic-v2-ipv4.sh
+++ b/scripts/testcase/testcase-basic-v2-ipv4.sh
@@ -14,6 +14,7 @@ export CNI_SPEC_TEMPLATE_VERSION=2.0
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-basic-v2-ipv6.sh
+++ b/scripts/testcase/testcase-basic-v2-ipv6.sh
@@ -14,6 +14,7 @@ export CNI_SPEC_TEMPLATE_VERSION=2.0
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-basic-v2.sh
+++ b/scripts/testcase/testcase-basic-v2.sh
@@ -14,6 +14,7 @@ export CNI_SPEC_TEMPLATE_VERSION=2.0
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-basic.sh
+++ b/scripts/testcase/testcase-basic.sh
@@ -12,6 +12,7 @@ export CNI_SPEC_TEMPLATE
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-calico-v2.sh
+++ b/scripts/testcase/testcase-calico-v2.sh
@@ -19,6 +19,7 @@ export CNI_SPEC_TEMPLATE_VERSION=2.0
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-calico.sh
+++ b/scripts/testcase/testcase-calico.sh
@@ -17,6 +17,7 @@ export CALICO_CNI_SPEC_TEMPLATE
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-cilium-faststart-v2.sh
+++ b/scripts/testcase/testcase-cilium-faststart-v2.sh
@@ -16,6 +16,7 @@ export CNI_SPEC_TEMPLATE_VERSION=2.0
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-cilium-faststart.sh
+++ b/scripts/testcase/testcase-cilium-faststart.sh
@@ -14,6 +14,7 @@ export CNI_SPEC_TEMPLATE
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-cilium-v2.sh
+++ b/scripts/testcase/testcase-cilium-v2.sh
@@ -16,6 +16,7 @@ export CNI_SPEC_TEMPLATE_VERSION=2.0
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-cilium.sh
+++ b/scripts/testcase/testcase-cilium.sh
@@ -14,6 +14,7 @@ export CNI_SPEC_TEMPLATE
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-directpath-v2.sh
+++ b/scripts/testcase/testcase-directpath-v2.sh
@@ -16,6 +16,7 @@ export CNI_SPEC_TEMPLATE_VERSION=2.0
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-directpath.sh
+++ b/scripts/testcase/testcase-directpath.sh
@@ -14,6 +14,7 @@ export CNI_SPEC_TEMPLATE
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-dualstack-v2.sh
+++ b/scripts/testcase/testcase-dualstack-v2.sh
@@ -14,6 +14,7 @@ export CNI_SPEC_TEMPLATE_VERSION=2.0
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-dualstack.sh
+++ b/scripts/testcase/testcase-dualstack.sh
@@ -12,6 +12,7 @@ export CNI_SPEC_TEMPLATE
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-ipv6-v2.sh
+++ b/scripts/testcase/testcase-ipv6-v2.sh
@@ -14,6 +14,7 @@ export CNI_SPEC_TEMPLATE_VERSION=2.0
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-mtu.sh
+++ b/scripts/testcase/testcase-mtu.sh
@@ -13,6 +13,7 @@ export CNI_SPEC_TEMPLATE
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in
@@ -45,6 +46,7 @@ function before_test() {
   }
   export -f curl
 
+  # shellcheck disable=SC2329
   function route() {
     # shellcheck disable=SC2317
     echo 'Kernel IP routing table

--- a/scripts/testcase/testcase-watchdog-cilium-faststart-unhealthy-v2.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-faststart-unhealthy-v2.sh
@@ -19,6 +19,7 @@ export TEST_WANT_EXIT_CODE=24
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in
@@ -59,7 +60,7 @@ function before_test() {
   }
   export -f curl
 
-  # shellcheck disable=SC2317
+  # shellcheck disable=SC2317,SC2329
   function sleep() {
     echo "[MOCK called] sleep $*"
     echo "[MOCK] this test expects a delay during fast start."

--- a/scripts/testcase/testcase-watchdog-cilium-faststart-unhealthy.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-faststart-unhealthy.sh
@@ -17,6 +17,7 @@ export TEST_WANT_EXIT_CODE=24
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in
@@ -57,7 +58,7 @@ function before_test() {
   }
   export -f curl
 
-  # shellcheck disable=SC2317
+  # shellcheck disable=SC2317,SC2329
   function sleep() {
     echo "[MOCK called] sleep $*"
     echo "[MOCK] this test expects a delay during fast start."

--- a/scripts/testcase/testcase-watchdog-cilium-faststart-v2.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-faststart-v2.sh
@@ -19,6 +19,7 @@ export TEST_WANT_EXIT_CODE=24
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in
@@ -56,7 +57,7 @@ function before_test() {
   }
   export -f curl
 
-  # shellcheck disable=SC2317
+  # shellcheck disable=SC2317,SC2329
   function sleep() {
     echo "[MOCK called] sleep $*"
     echo "[MOCK] this test expects a delay during fast start."

--- a/scripts/testcase/testcase-watchdog-cilium-faststart-wait.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-faststart-wait.sh
@@ -17,6 +17,7 @@ export TEST_WANT_EXIT_CODE=${TEST_EXIT_CODE_SLEEP}
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-watchdog-cilium-faststart.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-faststart.sh
@@ -17,6 +17,7 @@ export TEST_WANT_EXIT_CODE=24
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in
@@ -54,7 +55,7 @@ function before_test() {
   }
   export -f curl
 
-  # shellcheck disable=SC2317
+  # shellcheck disable=SC2317,SC2329
   function sleep() {
     echo "[MOCK called] sleep $*"
     echo "[MOCK] this test expects a delay during fast start."

--- a/scripts/testcase/testcase-watchdog-cilium-unhealthy-v2.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-unhealthy-v2.sh
@@ -19,6 +19,7 @@ export TEST_WANT_EXIT_CODE=24
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-watchdog-cilium-unhealthy.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-unhealthy.sh
@@ -17,6 +17,7 @@ export TEST_WANT_EXIT_CODE=24
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-watchdog-cilium-v2.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-v2.sh
@@ -20,6 +20,7 @@ TEST_WANT_EXIT_CODE=${TEST_EXIT_CODE_SLEEP}
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-watchdog-cilium.sh
+++ b/scripts/testcase/testcase-watchdog-cilium.sh
@@ -18,6 +18,7 @@ TEST_WANT_EXIT_CODE=${TEST_EXIT_CODE_SLEEP}
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-watchdog-v2.sh
+++ b/scripts/testcase/testcase-watchdog-v2.sh
@@ -18,6 +18,7 @@ TEST_WANT_EXIT_CODE=${TEST_EXIT_CODE_SLEEP}
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in

--- a/scripts/testcase/testcase-watchdog.sh
+++ b/scripts/testcase/testcase-watchdog.sh
@@ -16,6 +16,7 @@ TEST_WANT_EXIT_CODE=${TEST_EXIT_CODE_SLEEP}
 
 function before_test() {
 
+  # shellcheck disable=SC2329
   function curl() {
     # shellcheck disable=SC2317
     case "$*" in


### PR DESCRIPTION
Not removing SC2317 for now in case of upstream reverts.