### PR TITLE
Watch node object for podCIDR instead of crash + wait for restart

### DIFF
--- a/scripts/testcase/testcase-basic-v2-ipv4.sh
+++ b/scripts/testcase/testcase-basic-v2-ipv4.sh
@@ -21,8 +21,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://10.0.0.1:443/api/v1/nodes/*)
-        echo '{
+      *https://10.0.0.1:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -38,7 +38,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *)
         #unsupported

--- a/scripts/testcase/testcase-basic-v2-ipv6.sh
+++ b/scripts/testcase/testcase-basic-v2-ipv6.sh
@@ -21,8 +21,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *"https://[fd20::1]:443/api/v1/nodes/"*)
-        echo '{
+      *"https://[fd20::1]:443/api/v1/nodes"*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -38,7 +38,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *)
         #unsupported

--- a/scripts/testcase/testcase-basic-v2.sh
+++ b/scripts/testcase/testcase-basic-v2.sh
@@ -21,8 +21,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -38,7 +38,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *)
         #unsupported

--- a/scripts/testcase/testcase-basic.sh
+++ b/scripts/testcase/testcase-basic.sh
@@ -19,8 +19,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -36,7 +36,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *)
         #unsupported

--- a/scripts/testcase/testcase-calico-v2.sh
+++ b/scripts/testcase/testcase-calico-v2.sh
@@ -26,8 +26,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -43,7 +43,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *)
         #unsupported

--- a/scripts/testcase/testcase-calico.sh
+++ b/scripts/testcase/testcase-calico.sh
@@ -24,8 +24,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -41,7 +41,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *)
         #unsupported

--- a/scripts/testcase/testcase-cilium-faststart-v2.sh
+++ b/scripts/testcase/testcase-cilium-faststart-v2.sh
@@ -23,8 +23,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -40,7 +40,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *http://localhost:63197/*)
         echo 'healthz'

--- a/scripts/testcase/testcase-cilium-faststart.sh
+++ b/scripts/testcase/testcase-cilium-faststart.sh
@@ -21,8 +21,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -38,7 +38,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *http://localhost:63197/*)
         echo 'healthz'

--- a/scripts/testcase/testcase-cilium-v2.sh
+++ b/scripts/testcase/testcase-cilium-v2.sh
@@ -23,8 +23,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -40,7 +40,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *http://localhost:63197/*)
         echo 'healthz'

--- a/scripts/testcase/testcase-cilium.sh
+++ b/scripts/testcase/testcase-cilium.sh
@@ -21,8 +21,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -38,7 +38,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *http://localhost:63197/*)
         echo 'healthz'

--- a/scripts/testcase/testcase-directpath-v2.sh
+++ b/scripts/testcase/testcase-directpath-v2.sh
@@ -24,9 +24,9 @@ function before_test() {
         # call to GCE metadata server
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
         # call to kube-apiserver
-        echo '{
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -42,7 +42,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *)
         # unmatched call

--- a/scripts/testcase/testcase-directpath.sh
+++ b/scripts/testcase/testcase-directpath.sh
@@ -22,9 +22,9 @@ function before_test() {
         # call to GCE metadata server
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
         # call to kube-apiserver
-        echo '{
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -40,7 +40,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *)
         # unmatched call

--- a/scripts/testcase/testcase-dualstack-v2.sh
+++ b/scripts/testcase/testcase-dualstack-v2.sh
@@ -22,9 +22,9 @@ function before_test() {
         # call to GCE metadata server
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
         # call to kube-apiserver
-        echo '{
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                     "cloud.google.com/gke-stack-type": "IPV4_IPV6"
@@ -42,7 +42,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *)
         # unmatched call

--- a/scripts/testcase/testcase-dualstack.sh
+++ b/scripts/testcase/testcase-dualstack.sh
@@ -20,9 +20,9 @@ function before_test() {
         # call to GCE metadata server
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
         # call to kube-apiserver
-        echo '{
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                     "cloud.google.com/gke-stack-type": "IPV4_IPV6"
@@ -40,7 +40,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *)
         # unmatched call

--- a/scripts/testcase/testcase-ipv6-v2.sh
+++ b/scripts/testcase/testcase-ipv6-v2.sh
@@ -22,9 +22,9 @@ function before_test() {
         # call to GCE metadata server
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
         # call to kube-apiserver
-        echo '{
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                     "cloud.google.com/gke-stack-type": "IPV6"
@@ -41,7 +41,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *)
         # unmatched call

--- a/scripts/testcase/testcase-mtu.sh
+++ b/scripts/testcase/testcase-mtu.sh
@@ -20,8 +20,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -37,7 +37,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *)
         #unsupported

--- a/scripts/testcase/testcase-watch-fail.sh
+++ b/scripts/testcase/testcase-watch-fail.sh
@@ -6,13 +6,11 @@ export ENABLE_BANDWIDTH_PLUGIN=false
 export ENABLE_CILIUM_PLUGIN=false
 export ENABLE_MASQUERADE=false
 export ENABLE_IPV6=false
-export RUN_CNI_WATCHDOG=true
 
 CNI_SPEC_TEMPLATE=$(cat testdata/spec-template.json)
 export CNI_SPEC_TEMPLATE
 
-# shellcheck disable=SC2034
-TEST_WANT_EXIT_CODE=${TEST_EXIT_CODE_SLEEP}
+export TEST_WANT_EXIT_CODE=1
 
 function before_test() {
 
@@ -34,10 +32,6 @@ function before_test() {
                   "uid": "f2353a2f-ca8c-4ca0-8dd3-ad1f964a54f0"
                 },
                 "spec": {
-                  "podCIDR": "10.52.1.0/24",
-                  "podCIDRs": [
-                    "10.52.1.0/24"
-                  ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
               }}'
@@ -52,16 +46,11 @@ function before_test() {
 }
 
 function verify() {
-  local expected
   local actual
 
-  expected=$(jq -S . <"testdata/expected-basic.json")
-  actual=$(jq -S . <"/host/etc/cni/net.d/${CNI_SPEC_NAME}")
-
-  if [ "$expected" != "$actual" ] ; then
-    echo "Expected cni_spec value:"
-    echo "$expected"
-    echo "but actual was"
+  if [[ -f "/host/etc/cni/net.d/${CNI_SPEC_NAME}" ]]; then
+    actual=$(jq -S . <"/host/etc/cni/net.d/${CNI_SPEC_NAME}")
+    echo "Expected CNI config to be missing, but it has:"
     echo "$actual"
     return 1
   fi

--- a/scripts/testcase/testcase-watch-fast.sh
+++ b/scripts/testcase/testcase-watch-fast.sh
@@ -6,13 +6,9 @@ export ENABLE_BANDWIDTH_PLUGIN=false
 export ENABLE_CILIUM_PLUGIN=false
 export ENABLE_MASQUERADE=false
 export ENABLE_IPV6=false
-export RUN_CNI_WATCHDOG=true
 
 CNI_SPEC_TEMPLATE=$(cat testdata/spec-template.json)
 export CNI_SPEC_TEMPLATE
-
-# shellcheck disable=SC2034
-TEST_WANT_EXIT_CODE=${TEST_EXIT_CODE_SLEEP}
 
 function before_test() {
 
@@ -30,7 +26,7 @@ function before_test() {
                   },
                   "creationTimestamp": "2024-01-03T11:54:01Z",
                   "name": "gke-my-cluster-default-pool-128bc25d-9c94",
-                  "resourceVersion": "891003",
+                  "resourceVersion": "891004",
                   "uid": "f2353a2f-ca8c-4ca0-8dd3-ad1f964a54f0"
                 },
                 "spec": {
@@ -41,6 +37,11 @@ function before_test() {
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
               }}'
+        # This curl never returns but we expect the calling script to be able to
+        # consume the first object above (which contains .spec.podCIDR).
+        # Not using `sleep infinity` here because `sleep` may be mocked in tests.
+        while :; do :; done
+        exit 1
         ;;
       *)
         #unsupported

--- a/scripts/testcase/testcase-watch-retry.sh
+++ b/scripts/testcase/testcase-watch-retry.sh
@@ -1,0 +1,114 @@
+export KUBERNETES_SERVICE_HOST=kubernetes.default.svc
+export KUBERNETES_SERVICE_PORT=443
+
+export ENABLE_CALICO_NETWORK_POLICY=false
+export ENABLE_BANDWIDTH_PLUGIN=false
+export ENABLE_CILIUM_PLUGIN=false
+export ENABLE_MASQUERADE=false
+export ENABLE_IPV6=false
+
+CNI_SPEC_TEMPLATE=$(cat testdata/spec-template.json)
+export CNI_SPEC_TEMPLATE
+
+function before_test() {
+
+  # shellcheck disable=SC2329
+  function curl() {
+    # shellcheck disable=SC2317
+    case "$*" in
+      *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
+        echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
+        ;;
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        # Return no matching object on the first attempt, then a matching one on the following.
+        # This curl is called in a subshell so not possible to persist state using a variable.
+        if [[ ! -f /testcase-watch-retry-curl-good ]]; then
+          echo -n >/testcase-watch-retry-curl-good
+          echo '{"object":{
+                  "metadata": {
+                    "labels": {
+                    },
+                    "creationTimestamp": "2024-01-03T11:54:01Z",
+                    "name": "gke-my-cluster-default-pool-128bc25d-9c94",
+                    "resourceVersion": "891003",
+                    "uid": "f2353a2f-ca8c-4ca0-8dd3-ad1f964a54f0"
+                  },
+                  "spec": {
+                    "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
+                  }
+                }}'
+          return
+        fi
+        echo '{"object":{
+                "metadata": {
+                  "labels": {
+                  },
+                  "creationTimestamp": "2024-01-03T11:54:01Z",
+                  "name": "gke-my-cluster-default-pool-128bc25d-9c94",
+                  "resourceVersion": "891003",
+                  "uid": "f2353a2f-ca8c-4ca0-8dd3-ad1f964a54f0"
+                },
+                "spec": {
+                  "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
+                }
+              }}'
+        echo '{"object":{
+                "metadata": {
+                  "labels": {
+                  },
+                  "creationTimestamp": "2024-01-03T11:54:01Z",
+                  "name": "gke-my-cluster-default-pool-128bc25d-9c94",
+                  "resourceVersion": "891004",
+                  "uid": "f2353a2f-ca8c-4ca0-8dd3-ad1f964a54f0"
+                },
+                "spec": {
+                  "podCIDR": "10.52.1.0/24",
+                  "podCIDRs": [
+                    "10.52.1.0/24"
+                  ],
+                  "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
+                }
+              }}'
+        echo '{"object":{
+                "metadata": {
+                  "labels": {
+                  },
+                  "creationTimestamp": "2024-01-03T11:54:01Z",
+                  "name": "gke-my-cluster-default-pool-128bc25d-9c94",
+                  "resourceVersion": "891005",
+                  "uid": "f2353a2f-ca8c-4ca0-8dd3-ad1f964a54f0"
+                },
+                "spec": {
+                  "podCIDR": "10.52.1.1/24",
+                  "podCIDRs": [
+                    "10.52.1.1/24"
+                  ],
+                  "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
+                }
+              }}'
+        ;;
+      *)
+        #unsupported
+        exit 1
+    esac
+  }
+  export -f curl
+
+}
+
+function verify() {
+  local expected
+  local actual
+
+  expected=$(jq -S . <"testdata/expected-basic.json")
+  actual=$(jq -S . <"/host/etc/cni/net.d/${CNI_SPEC_NAME}")
+
+  if [ "$expected" != "$actual" ] ; then
+    echo "Expected cni_spec value:"
+    echo "$expected"
+    echo "but actual was"
+    echo "$actual"
+    return 1
+  fi
+
+}

--- a/scripts/testcase/testcase-watch.sh
+++ b/scripts/testcase/testcase-watch.sh
@@ -6,13 +6,9 @@ export ENABLE_BANDWIDTH_PLUGIN=false
 export ENABLE_CILIUM_PLUGIN=false
 export ENABLE_MASQUERADE=false
 export ENABLE_IPV6=false
-export RUN_CNI_WATCHDOG=true
 
 CNI_SPEC_TEMPLATE=$(cat testdata/spec-template.json)
 export CNI_SPEC_TEMPLATE
-
-# shellcheck disable=SC2034
-TEST_WANT_EXIT_CODE=${TEST_EXIT_CODE_SLEEP}
 
 function before_test() {
 
@@ -34,9 +30,39 @@ function before_test() {
                   "uid": "f2353a2f-ca8c-4ca0-8dd3-ad1f964a54f0"
                 },
                 "spec": {
+                  "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
+                }
+              }}'
+        echo '{"object":{
+                "metadata": {
+                  "labels": {
+                  },
+                  "creationTimestamp": "2024-01-03T11:54:01Z",
+                  "name": "gke-my-cluster-default-pool-128bc25d-9c94",
+                  "resourceVersion": "891004",
+                  "uid": "f2353a2f-ca8c-4ca0-8dd3-ad1f964a54f0"
+                },
+                "spec": {
                   "podCIDR": "10.52.1.0/24",
                   "podCIDRs": [
                     "10.52.1.0/24"
+                  ],
+                  "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
+                }
+              }}'
+        echo '{"object":{
+                "metadata": {
+                  "labels": {
+                  },
+                  "creationTimestamp": "2024-01-03T11:54:01Z",
+                  "name": "gke-my-cluster-default-pool-128bc25d-9c94",
+                  "resourceVersion": "891005",
+                  "uid": "f2353a2f-ca8c-4ca0-8dd3-ad1f964a54f0"
+                },
+                "spec": {
+                  "podCIDR": "10.52.1.1/24",
+                  "podCIDRs": [
+                    "10.52.1.1/24"
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }

--- a/scripts/testcase/testcase-watchdog-cilium-faststart-unhealthy-v2.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-faststart-unhealthy-v2.sh
@@ -26,8 +26,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -43,7 +43,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *http://localhost:63197/*)
         # Return unhealthy on the first attempt, then exit on the following.

--- a/scripts/testcase/testcase-watchdog-cilium-faststart-unhealthy.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-faststart-unhealthy.sh
@@ -24,8 +24,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -41,7 +41,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *http://localhost:63197/*)
         # Return unhealthy on the first attempt, then exit on the following.

--- a/scripts/testcase/testcase-watchdog-cilium-faststart-v2.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-faststart-v2.sh
@@ -26,8 +26,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -43,7 +43,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *http://localhost:63197/*)
         # With fast-start enabled, CNI config should have been written

--- a/scripts/testcase/testcase-watchdog-cilium-faststart-wait.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-faststart-wait.sh
@@ -24,8 +24,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -41,7 +41,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *http://localhost:63197/*)
         # This test shouldn't reach this. It should hit an exit-by-sleep

--- a/scripts/testcase/testcase-watchdog-cilium-faststart.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-faststart.sh
@@ -24,8 +24,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -41,7 +41,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *http://localhost:63197/*)
         # With fast-start enabled, CNI config should have been written

--- a/scripts/testcase/testcase-watchdog-cilium-unhealthy-v2.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-unhealthy-v2.sh
@@ -26,8 +26,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -43,7 +43,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *http://localhost:63197/*)
         # Return unhealthy on the first attempt, then exit on the following.
@@ -59,6 +59,12 @@ function before_test() {
     esac
   }
   export -f curl
+
+  # shellcheck disable=SC2317,SC2329
+  function sleep() {
+    echo "[MOCK called] sleep $*"
+  }
+  export -f sleep
 
 }
 

--- a/scripts/testcase/testcase-watchdog-cilium-unhealthy.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-unhealthy.sh
@@ -24,8 +24,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -41,7 +41,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *http://localhost:63197/*)
         # Return unhealthy on the first attempt, then exit on the following.
@@ -57,6 +57,12 @@ function before_test() {
     esac
   }
   export -f curl
+
+  # shellcheck disable=SC2317,SC2329
+  function sleep() {
+    echo "[MOCK called] sleep $*"
+  }
+  export -f sleep
 
 }
 

--- a/scripts/testcase/testcase-watchdog-cilium-v2.sh
+++ b/scripts/testcase/testcase-watchdog-cilium-v2.sh
@@ -27,8 +27,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -44,7 +44,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *http://localhost:63197/*)
         echo 'healthz'

--- a/scripts/testcase/testcase-watchdog-cilium.sh
+++ b/scripts/testcase/testcase-watchdog-cilium.sh
@@ -25,8 +25,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -42,7 +42,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *http://localhost:63197/*)
         echo 'healthz'

--- a/scripts/testcase/testcase-watchdog-v2.sh
+++ b/scripts/testcase/testcase-watchdog-v2.sh
@@ -25,8 +25,8 @@ function before_test() {
       *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
         echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
-        echo '{
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
+        echo '{"object":{
                 "metadata": {
                   "labels": {
                   },
@@ -42,7 +42,7 @@ function before_test() {
                   ],
                   "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
                 }
-              }'
+              }}'
         ;;
       *)
         #unsupported

--- a/scripts/testcase/tpl-testcase.sh
+++ b/scripts/testcase/tpl-testcase.sh
@@ -24,7 +24,7 @@ function before_test() {
         # call to GCE metadata server
         echo '{}'
         ;;
-      *https://kubernetes.default.svc:443/api/v1/nodes/*)
+      *https://kubernetes.default.svc:443/api/v1/nodes*)
         # call to kube-apiserver
         echo '{}'
         ;;


### PR DESCRIPTION
This can save up to 10 seconds before Kubelet decides to restart the pod after the crash.

Also made some logging improvements.

/assign @marqc 
/assign @sypakine 
/hold