### PR TITLE
Stop dependabot bumps in `/tools`; we routinely sync from upstream

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,7 +8,3 @@ updates:
   directory: /
   schedule:
     interval: weekly
-- package-ecosystem: gomod 
-  directory: /tools
-  schedule:
-    interval: weekly


### PR DESCRIPTION
Upstream: thockin/go-build-template

This repo lacks checks around `/tools`, and automated bump may bring in unexpected breakage. They're not included in the artifacts built anyway.

/assign @MrHohn 