### PR TITLE
Remove deprecated MAINTAINER instructions from Dockerfiles

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -14,8 +14,6 @@
 
 FROM {ARG_FROM}
 
-MAINTAINER Zihong Zheng <zihongz@google.com>
-
 # When building, we can pass a unique value (e.g. `date +%s`) for this arg,
 # which will force a rebuild from here (by invalidating docker's cache).
 ARG FORCE_REBUILD=0

--- a/scripts/Dockerfile.in
+++ b/scripts/Dockerfile.in
@@ -118,8 +118,6 @@ COPY bin/{ARG_OS}_{ARG_ARCH}/{ARG_BIN} /{ARG_BIN}
 
 FROM {ARG_FROM}
 
-MAINTAINER Jingyuan Liang <jingyuanliang@google.com>
-
 COPY --from=stuff / /
 
 # This container has to run as root for iptables. Be explicit here.


### PR DESCRIPTION
https://docs.docker.com/reference/build-checks/maintainer-deprecated/

/assign @MrHohn 