### PR TITLE
Use protobuf encoding for core K8s APIs in netd

### DIFF
--- a/pkg/metrics/collector/netlink_metrics.go
+++ b/pkg/metrics/collector/netlink_metrics.go
@@ -30,6 +30,7 @@ import (
 	"golang.org/x/sys/unix"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
@@ -128,6 +129,7 @@ func createPodWatch() error {
 	if err != nil {
 		return err
 	}
+	config.ContentType = runtime.ContentTypeProtobuf
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/pkg/metrics/collector/pod_ip_metrics.go
+++ b/pkg/metrics/collector/pod_ip_metrics.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -162,6 +163,7 @@ func NewPodIPMetricsCollector() (Collector, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error creating in-cluster config: %v", err)
 	}
+	config.ContentType = runtime.ContentTypeProtobuf
 
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
If not specified explicitly, JSON encoding is used by default when talking to kube-apiserver.

For core K8s API objects like Pods, Nodes, etc., we can use protobuf encoding which reduces CPU consumption related to (de)serialization, reduces overall latency of the API calls, reduces memory footprint, reduces the amount of work performed by the GC and results in quicker propagation of objects to event handlers of shared informers.