### PR TITLE
Revert "Bump base image to distroless-iptables:v0.6.3"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ ALL_PLATFORMS ?= linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/s390x
 
 # The "FROM" part of the Dockerfile.  This should be a manifest-list which
 # supports all of the platforms listed in ALL_PLATFORMS.
-BASE_IMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.6.3
+BASE_IMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.6.2
 
 # Where to push the docker images.
 REGISTRY ?= gcr.io/gke-release-staging

--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -30,7 +30,7 @@ ALL_PLATFORMS ?= linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/s390x
 
 # The "FROM" part of the Dockerfile.  This should be a manifest-list which
 # supports all of the platforms listed in ALL_PLATFORMS.
-BASE_IMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.6.3
+BASE_IMAGE ?= registry.k8s.io/build-image/distroless-iptables:v0.6.2
 
 # Where to push the docker images.
 REGISTRY ?= gcr.io/gke-release-staging


### PR DESCRIPTION
Reverts GoogleCloudPlatform/netd#365 which triggered https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1083095

/assign @MrHohn 