### PR TITLE
Pin cpplint to 1.6.1, since 2.0.0 causes unexpected lint failures

### DIFF
--- a/scripts/Makefile
+++ b/scripts/Makefile
@@ -394,7 +394,7 @@ lint:
 	    --env HTTP_PROXY="$(HTTP_PROXY)"    \
 	    --env HTTPS_PROXY="$(HTTPS_PROXY)"  \
 	    python:3-alpine                     \
-	    sh -c 'pip install cpplint && cpplint --recursive .'
+	    sh -c 'pip install cpplint==1.6.1 && cpplint --recursive .'
 	echo "Linting install-cni.sh"
 	docker run                              \
 	    -i                                  \


### PR DESCRIPTION
```
inotify.c:186:  Add #include <cstdio> for printf  [build/include_what_you_use] [4]
```

/assign @MrHohn 