### PR TITLE
Use NODE_NAME instead of HOSTNAME for node name if set

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -115,7 +115,7 @@ fetch_node_object() {
   fi
 
   local token
-  local node_url="https://${host}:${KUBERNETES_SERVICE_PORT}/api/v1/nodes?watch=true&timeoutSeconds=${timeout}&fieldSelector=metadata.name=${HOSTNAME}"
+  local node_url="https://${host}:${KUBERNETES_SERVICE_PORT}/api/v1/nodes?watch=true&timeoutSeconds=${timeout}&fieldSelector=metadata.name=${NODE_NAME:-${HOSTNAME}}"
 
   for ((i=1; i<=attempts; i++)); do
     log "Watching attempt #${i} at ${node_url}"

--- a/scripts/testcase/testcase-nodename.sh
+++ b/scripts/testcase/testcase-nodename.sh
@@ -1,0 +1,67 @@
+export KUBERNETES_SERVICE_HOST=kubernetes.default.svc
+export KUBERNETES_SERVICE_PORT=443
+
+export ENABLE_CALICO_NETWORK_POLICY=false
+export ENABLE_CILIUM_PLUGIN=false
+export ENABLE_MASQUERADE=false
+export ENABLE_IPV6=false
+
+export NODE_NAME=gke-my-cluster-default-pool-128bc25d-9c94
+export HOSTNAME=unexpected
+
+CNI_SPEC_TEMPLATE=$(cat testdata/spec-template.json)
+export CNI_SPEC_TEMPLATE
+
+function before_test() {
+
+  # shellcheck disable=SC2329
+  function curl() {
+    # shellcheck disable=SC2317
+    case "$*" in
+      *http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0*)
+        echo '{"ipv6s": ["2600:1900:4000:318:0:7:0:0"]}'
+        ;;
+      *https://kubernetes.default.svc:443/api/v1/nodes*gke-my-cluster-default-pool-128bc25d-9c94*)
+        echo '{"object":{
+                "metadata": {
+                  "labels": {
+                  },
+                  "creationTimestamp": "2024-01-03T11:54:01Z",
+                  "name": "gke-my-cluster-default-pool-128bc25d-9c94",
+                  "resourceVersion": "891003",
+                  "uid": "f2353a2f-ca8c-4ca0-8dd3-ad1f964a54f0"
+                },
+                "spec": {
+                  "podCIDR": "10.52.1.0/24",
+                  "podCIDRs": [
+                    "10.52.1.0/24"
+                  ],
+                  "providerID": "gce://my-gke-project/us-central1-c/gke-my-cluster-default-pool-128bc25d-9c94"
+                }
+              }}'
+        ;;
+      *)
+        #unsupported
+        exit 1
+    esac
+  }
+  export -f curl
+
+}
+
+function verify() {
+  local expected
+  local actual
+
+  expected=$(jq -S . <"testdata/expected-basic.json")
+  actual=$(jq -S . <"/host/etc/cni/net.d/${CNI_SPEC_NAME}")
+
+  if [ "$expected" != "$actual" ] ; then
+    echo "Expected cni_spec value:"
+    echo "$expected"
+    echo "but actual was"
+    echo "$actual"
+    return 1
+  fi
+
+}


### PR DESCRIPTION
... in apiserver query for podCIDR; otherwise fall back to HOSTNAME.

We see unexpected customization of host name on node by users.

/assign @MrHohn 