### PR TITLE
pod_ip_metrics: use CURRENT_NODE_NAME env var as the node name if set

### DIFF
--- a/pkg/metrics/collector/pod_ip_metrics.go
+++ b/pkg/metrics/collector/pod_ip_metrics.go
@@ -170,9 +170,12 @@ func NewPodIPMetricsCollector() (Collector, error) {
 		return nil, fmt.Errorf("error creating clientset: %v", err)
 	}
 
-	nodeName, err := os.Hostname()
-	if err != nil {
-		return nil, fmt.Errorf("error getting hostname: %v", err)
+	nodeName := os.Getenv("CURRENT_NODE_NAME")
+	if nodeName == "" {
+		nodeName, err = os.Hostname()
+		if err != nil {
+			return nil, fmt.Errorf("error getting hostname: %v", err)
+		}
 	}
 
 	return &podIPMetricsCollector{


### PR DESCRIPTION
and only use os.Hostname() as a fallback to match the previous behavior.

The name CURRENT_NODE_NAME was chosen to match the existing usage in netlink_metrics.

/assign @MrHohn 