### PR TITLE
install-cni: rename env var NODE_NAME to CURRENT_NODE_NAME

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -115,7 +115,7 @@ fetch_node_object() {
   fi
 
   local token
-  local node_url="https://${host}:${KUBERNETES_SERVICE_PORT}/api/v1/nodes?watch=true&timeoutSeconds=${timeout}&fieldSelector=metadata.name=${NODE_NAME:-${HOSTNAME}}"
+  local node_url="https://${host}:${KUBERNETES_SERVICE_PORT}/api/v1/nodes?watch=true&timeoutSeconds=${timeout}&fieldSelector=metadata.name=${CURRENT_NODE_NAME:-${HOSTNAME}}"
 
   for ((i=1; i<=attempts; i++)); do
     log "Watching attempt #${i} at ${node_url}"

--- a/scripts/testcase/testcase-nodename.sh
+++ b/scripts/testcase/testcase-nodename.sh
@@ -6,7 +6,7 @@ export ENABLE_CILIUM_PLUGIN=false
 export ENABLE_MASQUERADE=false
 export ENABLE_IPV6=false
 
-export NODE_NAME=gke-my-cluster-default-pool-128bc25d-9c94
+export CURRENT_NODE_NAME=gke-my-cluster-default-pool-128bc25d-9c94
 export HOSTNAME=unexpected
 
 CNI_SPEC_TEMPLATE=$(cat testdata/spec-template.json)


### PR DESCRIPTION
This is to match the existing usage in netlink_metrics. The version with NODE_NAME naming was never released.

/assign @MrHohn 