### PR TITLE
Handle cloud.google.com/gke-dpv2-unified-cni node label

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -151,6 +151,11 @@ if [[ "${MIGRATE_TO_DPV2:-}" == "true" ]]; then
 fi
 
 if [[ "${ENABLE_CILIUM_PLUGIN}" == "true" ]]; then
+  dpv2_unified_cni=$(jq -r '.metadata.labels."cloud.google.com/gke-dpv2-unified-cni"' <<<"${node_object}")
+  log "Using Cilium plug-in; unified mode: '${dpv2_unified_cni}' (no action needed here if true)"
+  if [[ "${dpv2_unified_cni}" = "true" ]]; then
+    success
+  fi
   cilium_cni_config='{"type": "cilium-cni", "enable-route-mtu": true}'
   if [[ -n "${CILIUM_FAST_START_NAMESPACES:-}" ]]; then
     cilium_cni_config=$(jq --arg namespaces "${CILIUM_FAST_START_NAMESPACES:-}" '.["dpv2-fast-start-namespaces"] = $namespaces' <<<"${cilium_cni_config}")

--- a/scripts/testcase/testcase-basic-v2.sh
+++ b/scripts/testcase/testcase-basic-v2.sh
@@ -24,6 +24,7 @@ function before_test() {
         echo '{"object":{
                 "metadata": {
                   "labels": {
+                    "cloud.google.com/gke-dpv2-unified-cni": "true"
                   },
                   "creationTimestamp": "2024-01-03T11:54:01Z",
                   "name": "gke-my-cluster-default-pool-128bc25d-9c94",

--- a/scripts/testcase/testcase-calico-v2.sh
+++ b/scripts/testcase/testcase-calico-v2.sh
@@ -29,6 +29,7 @@ function before_test() {
         echo '{"object":{
                 "metadata": {
                   "labels": {
+                    "cloud.google.com/gke-dpv2-unified-cni": "true"
                   },
                   "creationTimestamp": "2024-01-03T11:54:01Z",
                   "name": "gke-my-cluster-default-pool-128bc25d-9c94",

--- a/scripts/testcase/testcase-calico.sh
+++ b/scripts/testcase/testcase-calico.sh
@@ -27,6 +27,7 @@ function before_test() {
         echo '{"object":{
                 "metadata": {
                   "labels": {
+                    "cloud.google.com/gke-dpv2-unified-cni": "true"
                   },
                   "creationTimestamp": "2024-01-03T11:54:01Z",
                   "name": "gke-my-cluster-default-pool-128bc25d-9c94",


### PR DESCRIPTION
Skip CNI config file writing when the node label is set to true and Cilium CNI is being used (to be handed over to anetd; include "natural" DPv2 and migrated nodes during DPv2 migration).

/assign @sugangli @pravk03 @sypakine 