### PR TITLE
Update TCPInfo Struct 

### DIFF
--- a/pkg/tcp_metrics/tcp/tcpinfo.go
+++ b/pkg/tcp_metrics/tcp/tcpinfo.go
@@ -130,4 +130,11 @@ type LinuxTCPInfo struct {
 	RcvOooPack uint32
 
 	SndWnd uint32
+	RcvWnd uint32
+
+	Rehash uint32
+
+	TotalRto           uint16
+	TotalRtoRecoveries uint16
+	TotalRtoTime       uint32
 }

--- a/pkg/tcp_metrics/tcp/tcpinfo_test.go
+++ b/pkg/tcp_metrics/tcp/tcpinfo_test.go
@@ -2,11 +2,22 @@ package tcp_test
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/GoogleCloudPlatform/netd/pkg/tcp_metrics/tcp"
+	"golang.org/x/sys/unix"
 )
 
-// TODO - sanity checks against syscall structs?
+func TestLinuxTCPInfoSize(t *testing.T) {
+	// This test checks if the size of our tcp.LinuxTCPInfo struct
+	// matches the size of the kernel's tcp_info struct from x/sys/unix.
+	// A mismatch can cause issues when parsing netlink messages.
+	var want = unsafe.Sizeof(unix.TCPInfo{})
+	var got = unsafe.Sizeof(tcp.LinuxTCPInfo{})
+	if got != want {
+		t.Errorf("sizeof(tcp.LinuxTCPInfo) = %d, want sizeof(unix.TCPInfo) = %d", got, want)
+	}
+}
 
 func TestState_String(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
Current version of netd expects `TCPInfo` struct size to be 232 Bytes. In Kernel version 6.2-rc1+ following additional fields were introduced in [tcp_info](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/tcp.h#n229) struct. 

- Rcv_wnd (uint32 - 4 Bytes)
- Rehash (uint32 - 4 Bytes)
- Total_rto (uint16 - 2 Bytes)
- Total_rto_recoveries (uint16 - 2Bytes)
- Total_rto_time (uint32 - 4Bytes)

When the pod watch is enabled in netd metric, lack of these fields causes excessive noise in logs due to [this](https://github.com/GoogleCloudPlatform/netd/blob/master/pkg/tcp_metrics/parser/parse.go#L241).

This PR updates the LinuxTCPInfo struct to reflect the current version of kernel's tcp_info struct and adds test to verify the struct size against kernel's tcp_info struct to remove [this](https://github.com/GoogleCloudPlatform/netd/blob/master/pkg/tcp_metrics/tcp/tcpinfo_test.go#L9) TODO.