### PR TITLE
Prevent InitPolicyRouting from resetting configs

### DIFF
--- a/pkg/controllers/netconf/network_config_controller.go
+++ b/pkg/controllers/netconf/network_config_controller.go
@@ -17,7 +17,6 @@ limitations under the License.
 package netconf
 
 import (
-	"context"
 	"reflect"
 	"sync"
 	"time"
@@ -29,6 +28,9 @@ import (
 	"github.com/GoogleCloudPlatform/netd/pkg/config"
 	"github.com/GoogleCloudPlatform/netd/pkg/kernel"
 )
+
+// GetKernelVersion is a variable for mocking in tests.
+var GetKernelVersion = kernel.GetVersion
 
 const (
 	brokenLocalUDPKernelVersionStart = "6.6.57"
@@ -55,7 +57,7 @@ func NewNetworkConfigController(enablePolicyRouting, enableSourceValidMark, excl
 	if excludeDNS {
 		configSet[0].Configs = append(configSet[0].Configs, config.ExcludeDNSIPRuleConfigs...)
 	}
-	kernelVersion, err := kernel.GetVersion()
+	kernelVersion, err := GetKernelVersion()
 	if err != nil {
 		glog.Errorf("Could not check kernel version: %v. Skip installing UDP exempt rule.", err)
 	} else {
@@ -70,11 +72,6 @@ func NewNetworkConfigController(enablePolicyRouting, enableSourceValidMark, excl
 		configSet:         configSet,
 		reconcileInterval: reconcileInterval,
 	}
-}
-
-// Init initializes the NetworkConfigController.
-func (n *NetworkConfigController) Init(ctx context.Context) error {
-	return config.InitPolicyRouting(ctx)
 }
 
 // Run runs the NetworkConfigController

--- a/pkg/controllers/netconf/network_config_controller_test.go
+++ b/pkg/controllers/netconf/network_config_controller_test.go
@@ -1,0 +1,151 @@
+package netconf
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/netd/pkg/config"
+
+	"k8s.io/apimachinery/pkg/util/version"
+)
+
+func TestNewNetworkConfigController(t *testing.T) {
+	originalGetKernelVersion := GetKernelVersion
+	defer func() {
+		GetKernelVersion = originalGetKernelVersion
+	}()
+
+	allEnabledConfigs := []config.Config{config.SourceValidMarkConfig}
+	allEnabledConfigs = append(allEnabledConfigs, config.ExcludeDNSIPRuleConfigs...)
+	allEnabledConfigs = append(allEnabledConfigs, config.ExcludeUDPIPRuleConfig)
+
+	testCases := []struct {
+		desc                  string
+		enablePolicyRouting   bool
+		enableSourceValidMark bool
+		excludeDNS            bool
+		kernelVersion         string
+		kernelErr             error
+		wantEnabled           bool
+		wantConfigs           []config.Config
+	}{
+		{
+			desc:        "all disabled, kernel error",
+			kernelErr:   errors.New("kernel version error"),
+			wantEnabled: false,
+			wantConfigs: []config.Config{},
+		},
+		{
+			desc:                "policy routing enabled",
+			enablePolicyRouting: true,
+			kernelVersion:       "5.0.0",
+			wantEnabled:         true,
+			wantConfigs:         []config.Config{},
+		},
+		{
+			desc:                  "source valid mark enabled",
+			enableSourceValidMark: true,
+			kernelVersion:         "5.0.0",
+			wantEnabled:           false,
+			wantConfigs:           []config.Config{config.SourceValidMarkConfig},
+		},
+		{
+			desc:          "exclude DNS enabled",
+			excludeDNS:    true,
+			kernelVersion: "5.0.0",
+			wantEnabled:   false,
+			wantConfigs:   config.ExcludeDNSIPRuleConfigs,
+		},
+		{
+			desc:          "low kernel version",
+			kernelVersion: "6.6.56",
+			wantEnabled:   false,
+			wantConfigs:   []config.Config{},
+		},
+		{
+			desc:          "impacted kernel version",
+			kernelVersion: "6.6.57",
+			wantEnabled:   false,
+			wantConfigs:   []config.Config{config.ExcludeUDPIPRuleConfig},
+		},
+		{
+			desc:          "higher impacted kernel version",
+			kernelVersion: "6.7.0",
+			wantEnabled:   false,
+			wantConfigs:   []config.Config{config.ExcludeUDPIPRuleConfig},
+		},
+		{
+			desc:                  "all enabled with impacted kernel",
+			enablePolicyRouting:   true,
+			enableSourceValidMark: true,
+			excludeDNS:            true,
+			kernelVersion:         "6.6.57",
+			wantEnabled:           true,
+			wantConfigs:           allEnabledConfigs,
+		},
+	}
+
+	for _, tc := range testCases {
+		config.PolicyRoutingConfigSet.Configs = nil
+		config.PolicyRoutingConfigSet.Enabled = false
+		t.Run(tc.desc, func(t *testing.T) {
+			GetKernelVersion = func() (*version.Version, error) {
+				if tc.kernelErr != nil {
+					return nil, tc.kernelErr
+				}
+				return version.MustParseGeneric(tc.kernelVersion), nil
+			}
+
+			reconcileInterval := 10 * time.Second
+			controller := NewNetworkConfigController(tc.enablePolicyRouting, tc.enableSourceValidMark, tc.excludeDNS, reconcileInterval)
+
+			if controller.reconcileInterval != reconcileInterval {
+				t.Errorf("controller.reconcileInterval = %v, want %v", controller.reconcileInterval, reconcileInterval)
+			}
+
+			if len(controller.configSet) != 1 {
+				t.Fatalf("len(controller.configSet) = %d, want 1", len(controller.configSet))
+			}
+
+			cs := controller.configSet[0]
+			if cs.Enabled != tc.wantEnabled {
+				t.Errorf("cs.Enabled = %v, want %v", cs.Enabled, tc.wantEnabled)
+			}
+
+			if !configsEqual(cs.Configs, tc.wantConfigs) {
+				t.Errorf("cs.Configs = %+v, want %+v", cs.Configs, tc.wantConfigs)
+			}
+		})
+	}
+}
+
+func configsEqual(a, b []config.Config) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if reflect.TypeOf(a[i]) != reflect.TypeOf(b[i]) {
+			return false
+		}
+
+		switch ta := a[i].(type) {
+		case config.SysctlConfig:
+			tb := b[i].(config.SysctlConfig)
+			if ta.Key != tb.Key || ta.Value != tb.Value || ta.DefaultValue != tb.DefaultValue {
+				return false
+			}
+		case config.IPRuleConfig:
+			tb := b[i].(config.IPRuleConfig)
+			if !reflect.DeepEqual(ta.Rule, tb.Rule) {
+				return false
+			}
+		default:
+			if !reflect.DeepEqual(a[i], b[i]) {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/pkg/utils/nodeinfo/nodeinfo.go
+++ b/pkg/utils/nodeinfo/nodeinfo.go
@@ -8,7 +8,7 @@ import (
 )
 
 // GetNodeName returns the current node name.
-func GetNodeName() (string, error) {
+var GetNodeName = func() (string, error) {
 	nodeName := os.Getenv("CURRENT_NODE_NAME")
 	if nodeName != "" {
 		return nodeName, nil


### PR DESCRIPTION
Previously, calling `InitPolicyRouting` would reset the global `PolicyRoutingConfigSet.Configs` slice. This could lead to the loss of configurations if the initialization order was not strictly controlled or if the function were ever called multiple times.

This commit corrects the behavior by refactoring out the global variable for policyRoutingConfigSet.

To properly test this fix and improve the overall design, `InitPolicyRouting` has been refactored to accept its dependencies (Kubernetes clientset, node name) as arguments. This enables dependency injection and isolated unit testing.

A new few new unit tests have been added to verify the corrected behavior and ensure that configurations are appended as expected.

/assign @jingyuanliang 