### PR TITLE
Allow IPv6 GRE in ip6tables

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -156,11 +156,12 @@ populate_ip6tables() {
   log "Ensuring IPv6 firewall rules with ip6tables"
 
   if ip6tables -w -L INPUT | grep "Chain INPUT (policy DROP)" > /dev/null; then
-    log "Add rules to accept all inbound TCP/UDP/ICMP/SCTP IPv6 packets"
+    log "Add rules to accept all inbound TCP/UDP/ICMP/SCTP/GRE IPv6 packets"
     ip6tables -A INPUT -w -p tcp -j ACCEPT
     ip6tables -A INPUT -w -p udp -j ACCEPT
     ip6tables -A INPUT -w -p icmpv6 -j ACCEPT
     ip6tables -A INPUT -w -p sctp -j ACCEPT
+    ip6tables -A INPUT -w -p gre -j ACCEPT
   fi
 
   if ip6tables -w -L FORWARD | grep "Chain FORWARD (policy DROP)" > /dev/null; then


### PR DESCRIPTION
gke-dpv2-unified-cni always injects ip6tables rules to allow IPv6 traffic. This change allows GRE ingress traffic so GRE tunnel can work on GKE node