### PR TITLE
fix: prevent panic on interface conversion in PodWatch

### DIFF
--- a/pkg/metrics/collector/netlink_metrics.go
+++ b/pkg/metrics/collector/netlink_metrics.go
@@ -166,15 +166,27 @@ func hasPodIP(pod *v1.Pod) bool {
 }
 
 func onPodAdd(podObj interface{}) {
-	pod := podObj.(*v1.Pod)
+	pod, ok := podObj.(*v1.Pod)
+	if !ok {
+		glog.Warningf("Expected object to be of type *v1.Pod, but got %T instead.", podObj)
+		return
+	}
 	if hasPodIP(pod) {
 		ipMap.safeIPWrite(pod.Status.PodIP, pod)
 	}
 }
 
 func onPodUpdate(oldPod, newPod interface{}) {
-	prevPod := oldPod.(*v1.Pod)
-	pod := newPod.(*v1.Pod)
+	prevPod, ok := oldPod.(*v1.Pod)
+	if !ok {
+		glog.Warningf("Expected object to be of type *v1.Pod, but got %T instead.", oldPod)
+		return
+	}
+	pod, ok := newPod.(*v1.Pod)
+	if !ok {
+		glog.Warningf("Expected object to be of type *v1.Pod, but got %T instead.", newPod)
+		return
+	}
 	if prevPod.Status.PodIP == pod.Status.PodIP {
 		return
 	}
@@ -188,7 +200,11 @@ func onPodUpdate(oldPod, newPod interface{}) {
 }
 
 func onPodDelete(podObj interface{}) {
-	pod := podObj.(*v1.Pod)
+	pod, ok := podObj.(*v1.Pod)
+	if !ok {
+		glog.Warningf("Expected object to be of type *v1.Pod, but got %T instead.", podObj)
+		return
+	}
 	if hasPodIP(pod) {
 		ipMap.safeIPDelete(pod.Status.PodIP)
 	}


### PR DESCRIPTION
Passing object which is not `*pod.V1` to  PodWatch controller _(informer)_ [OnPodDelete callback](https://github.com/GoogleCloudPlatform/netd/blob/c0d93736b25f1bf1ced0cb09d3639ec0c0e40910/pkg/metrics/collector/netlink_metrics.go#L191) causes panic on interface conversion.

```
panic: interface conversion: interface {} is cache.DeletedFinalStateUnknown, not *v1.Pod
```

As outlined in the [ResourceEventHandler interface](https://github.com/GoogleCloudPlatform/netd/blob/master/vendor/k8s.io/client-go/tools/cache/controller.go#L231C1-L234C57):

> //    This can
> //     happen if the watch is closed and misses the delete event and we don't
> //     notice the deletion until the subsequent re-list.

This PR adds type assertions to interface conversions for the controller inside `netlink_metrics.go`.