### PR TITLE
Replace cacert when system CA when the default cluster CA doesn't exist.

### DIFF
--- a/scripts/install-cni.sh
+++ b/scripts/install-cni.sh
@@ -122,6 +122,11 @@ fetch_node_object() {
     log "Watching attempt #${i} at ${node_url}"
     token=$(</var/run/secrets/kubernetes.io/serviceaccount/token)
     cacert="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    # Use system CA when cluster CA doesn't exist
+    if [[ ! -f "${cacert}" ]]; then
+      cacert="/etc/ssl/certs/ca-certificates.crt"
+    fi
+
     # Grab the first object seen with .spec.podCIDR set.
     # Note: curl process may be leaked until the next node update, or
     # timeoutSeconds, whichever earlier. Shouldn't be a major issue.

--- a/scripts/shell-test.sh
+++ b/scripts/shell-test.sh
@@ -82,4 +82,7 @@ timeout 1s sleep infinity && fail || { [[ "$?" == 124 ]] && pass || fail; }
 run_test base64_cmd
 [[ "$(echo -n AAA | base64 -w 0)" == QUFB ]] && pass || fail
 
+run_test system_ca_not_empty
+[[ -s "/etc/ssl/certs/ca-certificates.crt" ]] && pass || fail
+
 exit $FAIL_COUNT


### PR DESCRIPTION
This PR checkes the existence of K8s Clubster CA file, if not exist,replace it with System CA.