### PR TITLE
Fix nil pointer dereference in netd IPTables error handling

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -236,10 +236,13 @@ func (r IPTablesRuleConfig) Ensure(enabled bool) error {
 	} else if r.Spec.IsDefaultChain {
 		for _, rs := range r.RuleSpecs {
 			if err := r.IPT.Delete(r.Spec.TableName, r.Spec.ChainName, rs...); err != nil {
-				if eerr, eok := err.(*iptables.Error); !eok || eerr.ExitStatus() != 2 {
-					if !strings.Contains(eerr.Error(), "No chain/target/match") {
+				if eerr, eok := err.(*iptables.Error); eok {
+					if eerr.ExitStatus() != 2 && !strings.Contains(eerr.Error(), "No chain/target/match") {
 						return err
 					}
+				} else {
+					// Non-iptables error, bubble up
+					return err
 				}
 			}
 		}


### PR DESCRIPTION
## Overview
This PR fixes a crash in `netd` caused by unsafe handling of errors returned from `iptables` operations.

Previously, code paths in `IPTablesRuleConfig.Ensure` assumed all errors from `AppendUnique` and `Delete` would be of type `*iptables.Error`.  

If the error was not (e.g. `exec.ExitError` or another Go error type), the type assertion failed, leaving `eerr == nil`.  
The code still attempted to call `eerr.Error()` or `eerr.ExitStatus()`, resulting in a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation]
```

## Root Cause
- The condition mixed `!ok` with calls to methods on `eerr`.
- When `!ok`, `eerr` is nil, so dereferencing it caused a panic.

## Fix
- Refactor error handling to only access `ExitStatus()` or `Error()` when the type assertion succeeds.
- If the error is not an `*iptables.Error`, bubble it up cleanly instead of attempting to interpret it.

## Impact
- Prevents `netd` from crashing on unexpected iptables error types.
- Makes error handling more robust against changes in underlying iptables behavior or Go’s exec error types.

## Before
`!ok` branch still tried to dereference `eerr`, leading to panic.

## After
- Safe separation of the two cases:
  - Handle `*iptables.Error` with exit status logic.
  - Return all other error types without dereferencing.

## Testing
- Verified with synthetic error injections: non-iptables errors no longer crash the daemon.
- Normal iptables error handling remains unchanged.