### PR TITLE
Add sysctl metrics collector and update netd.yaml

### DIFF
--- a/netd.yaml
+++ b/netd.yaml
@@ -111,7 +111,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 data:
-  metrics_collectors: "conntrack,socket,kernel_metrics"
+  metrics_collectors: "conntrack,socket,kernel_metrics,sysctl_metrics"
   metrics_address: "localhost:10231"
 ---
 

--- a/pkg/metrics/collector/sysctl_metrics.go
+++ b/pkg/metrics/collector/sysctl_metrics.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2025 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	defaultProcSysNetIpv4IpLocalPortRangeFileLocation = "/proc/sys/net/ipv4/ip_local_port_range"
+)
+
+var (
+	ipLocalPortRangeDesc = prometheus.NewDesc(
+		"sysctl_net_ipv4_ip_local_port_range",
+		"The min and max values of net.ipv4.ip_local_port_range sysctl. Expected default is (32768, 60999).",
+		[]string{"boundary"}, nil,
+	)
+)
+
+type sysctlCollector struct {
+	ipLocalPortRangeFileLocation string
+}
+
+func init() {
+	registerCollector("sysctl_metrics", NewSysctlCollector)
+}
+
+func NewSysctlCollector() (Collector, error) {
+	return &sysctlCollector{
+		ipLocalPortRangeFileLocation: defaultProcSysNetIpv4IpLocalPortRangeFileLocation,
+	}, nil
+}
+
+func parseIPLocalPortRange(content string) (min, max uint64, err error) {
+	parts := strings.Fields(strings.TrimSpace(content))
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid ip_local_port_range format: expected 2 values, got %d. Content: %q", len(parts), content)
+	}
+
+	min, err = strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse min port value: %v", err)
+	}
+
+	max, err = strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse max port value: %v", err)
+	}
+
+	return min, max, nil
+}
+
+func (c *sysctlCollector) Update(ch chan<- prometheus.Metric) error {
+	data, err := os.ReadFile(c.ipLocalPortRangeFileLocation)
+	if err != nil {
+		return fmt.Errorf("failed to read ip_local_port_range from %s: %v", c.ipLocalPortRangeFileLocation, err)
+	}
+
+	min, max, err := parseIPLocalPortRange(string(data))
+	if err != nil {
+		return err
+	}
+
+	ch <- prometheus.MustNewConstMetric(ipLocalPortRangeDesc, prometheus.GaugeValue, float64(min), "min")
+	ch <- prometheus.MustNewConstMetric(ipLocalPortRangeDesc, prometheus.GaugeValue, float64(max), "max")
+
+	return nil
+}

--- a/pkg/metrics/collector/sysctl_metrics_test.go
+++ b/pkg/metrics/collector/sysctl_metrics_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package collector
+
+import (
+	"testing"
+)
+
+func TestParseIPLocalPortRange(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expectedMin uint64
+		expectedMax uint64
+		expectError bool
+	}{
+		{
+			name:        "default range",
+			input:       "32768\t60999",
+			expectedMin: 32768,
+			expectedMax: 60999,
+			expectError: false,
+		},
+		{
+			name:        "custom range with spaces",
+			input:       "1024 65535",
+			expectedMin: 1024,
+			expectedMax: 65535,
+			expectError: false,
+		},
+		{
+			name:        "range with newline",
+			input:       "32768\t60999\n",
+			expectedMin: 32768,
+			expectedMax: 60999,
+			expectError: false,
+		},
+		{
+			name:        "invalid - single value",
+			input:       "32768",
+			expectError: true,
+		},
+		{
+			name:        "invalid - too many values",
+			input:       "32768 60999 65535",
+			expectError: true,
+		},
+		{
+			name:        "invalid - non-numeric",
+			input:       "abc def",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			min, max, err := parseIPLocalPortRange(tt.input)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error but got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if min != tt.expectedMin {
+				t.Errorf("min: got %d, want %d", min, tt.expectedMin)
+			}
+			if max != tt.expectedMax {
+				t.Errorf("max: got %d, want %d", max, tt.expectedMax)
+			}
+		})
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -37,7 +37,7 @@ var mcfg struct {
 
 func init() {
 	flag.StringVar(&mcfg.enabledCollectors, "metrics-collectors", "",
-		"Enable given metrics collectors (options: conntrack,socket,kernel_metrics,netlink_metrics,pod_ip_metrics).")
+		"Enable given metrics collectors (options: conntrack,socket,kernel_metrics,netlink_metrics,pod_ip_metrics,sysctl_metrics).")
 	flag.StringVar(&mcfg.listenAddress, "metrics-address", "localhost:10231", "Address on which to expose metrics.")
 	flag.StringVar(&mcfg.procPath, "metrics-proc-path", "/proc", "Proc directory to read metrics.")
 	flag.StringVar(&mcfg.stackType, "stack-type", "IPV4", "Stack type.")


### PR DESCRIPTION
This PR introduces a new collector `sysctl_metrics` to netd. It parses `/proc/sys/net/ipv4/ip_local_port_range` and exposes the configured minimum and maximum values as Prometheus metrics:

- sysctl_net_ipv4_ip_local_port_range{boundary="min"}

- sysctl_net_ipv4_ip_local_port_range{boundary="max"}

This enables monitoring and alerting for unsafe port range configurations on the node in the future.
TESTED= `go test` and successfully scraped the metric in a live cluster.
<img width="2666" height="162" alt="image" src="https://github.com/user-attachments/assets/07803f65-2616-47de-8949-a395b53617e0" />
