### PR TITLE
fix(lint): avoid masking min/max built-in functions

### DIFF
--- a/pkg/metrics/collector/sysctl_metrics.go
+++ b/pkg/metrics/collector/sysctl_metrics.go
@@ -51,23 +51,23 @@ func NewSysctlCollector() (Collector, error) {
 	}, nil
 }
 
-func parseIPLocalPortRange(content string) (min, max uint64, err error) {
+func parseIPLocalPortRange(content string) (minPort, maxPort uint64, err error) {
 	parts := strings.Fields(strings.TrimSpace(content))
 	if len(parts) != 2 {
 		return 0, 0, fmt.Errorf("invalid ip_local_port_range format: expected 2 values, got %d. Content: %q", len(parts), content)
 	}
 
-	min, err = strconv.ParseUint(parts[0], 10, 64)
+	minPort, err = strconv.ParseUint(parts[0], 10, 64)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to parse min port value: %v", err)
 	}
 
-	max, err = strconv.ParseUint(parts[1], 10, 64)
+	maxPort, err = strconv.ParseUint(parts[1], 10, 64)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to parse max port value: %v", err)
 	}
 
-	return min, max, nil
+	return minPort, maxPort, nil
 }
 
 func (c *sysctlCollector) Update(ch chan<- prometheus.Metric) error {
@@ -76,13 +76,13 @@ func (c *sysctlCollector) Update(ch chan<- prometheus.Metric) error {
 		return fmt.Errorf("failed to read ip_local_port_range from %s: %v", c.ipLocalPortRangeFileLocation, err)
 	}
 
-	min, max, err := parseIPLocalPortRange(string(data))
+	minPort, maxPort, err := parseIPLocalPortRange(string(data))
 	if err != nil {
 		return err
 	}
 
-	ch <- prometheus.MustNewConstMetric(ipLocalPortRangeDesc, prometheus.GaugeValue, float64(min), "min")
-	ch <- prometheus.MustNewConstMetric(ipLocalPortRangeDesc, prometheus.GaugeValue, float64(max), "max")
+	ch <- prometheus.MustNewConstMetric(ipLocalPortRangeDesc, prometheus.GaugeValue, float64(minPort), "min")
+	ch <- prometheus.MustNewConstMetric(ipLocalPortRangeDesc, prometheus.GaugeValue, float64(maxPort), "max")
 
 	return nil
 }

--- a/pkg/metrics/collector/sysctl_metrics_test.go
+++ b/pkg/metrics/collector/sysctl_metrics_test.go
@@ -68,7 +68,7 @@ func TestParseIPLocalPortRange(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			min, max, err := parseIPLocalPortRange(tt.input)
+			minPort, maxPort, err := parseIPLocalPortRange(tt.input)
 			if tt.expectError {
 				if err == nil {
 					t.Errorf("expected error but got none")
@@ -79,11 +79,11 @@ func TestParseIPLocalPortRange(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 				return
 			}
-			if min != tt.expectedMin {
-				t.Errorf("min: got %d, want %d", min, tt.expectedMin)
+			if minPort != tt.expectedMin {
+				t.Errorf("min: got %d, want %d", minPort, tt.expectedMin)
 			}
-			if max != tt.expectedMax {
-				t.Errorf("max: got %d, want %d", max, tt.expectedMax)
+			if maxPort != tt.expectedMax {
+				t.Errorf("max: got %d, want %d", maxPort, tt.expectedMax)
 			}
 		})
 	}


### PR DESCRIPTION
Don't mask`min`/`max` built in functions.