### PR TITLE
Fix format string mismatches for go1.26 build

### DIFF
--- a/pkg/metrics/collector/kernel_metrics_test.go
+++ b/pkg/metrics/collector/kernel_metrics_test.go
@@ -43,7 +43,7 @@ TcpExt: 0 0 0 0 0 440 99 21800 3`
 		t.Errorf("failed parseNetstat, got %q", err)
 	}
 	if !mapContainsAll(got, want) {
-		t.Errorf("parseNetstatVals returns %+q, want %+q", got, want)
+		t.Errorf("parseNetstatVals returns %+v, want %+v", got, want)
 	}
 }
 
@@ -62,7 +62,7 @@ UdpLite: 0 0 0 0 0 0 0 0`
 		t.Errorf("failed parseNetstat, got %q", err)
 	}
 	if !mapContainsAll(got, want) {
-		t.Errorf("parseSnmpVals returns %+q, want %+q", got, want)
+		t.Errorf("parseSnmpVals returns %+v, want %+v", got, want)
 	}
 
 }

--- a/pkg/metrics/collector/netlink_metrics_test.go
+++ b/pkg/metrics/collector/netlink_metrics_test.go
@@ -43,7 +43,7 @@ func TestCreateStatMap(t *testing.T) {
 	statMap := createStatMap(snapshots)
 	want := map[*v1.Pod]netlinkStats{myPod: {retransmits: 8, tcpConnections: 2}}
 	if statMap[myPod] != want[myPod] {
-		t.Fatalf("Fatal, got %+q, wanted %+q", statMap, want)
+		t.Fatalf("Fatal, got %+v, wanted %+v", statMap, want)
 	}
 }
 


### PR DESCRIPTION
Go 1.26's printf vet check flags %+q applied to map values, which is only valid for strings, runes, integers, and Stringer/error types. Switch the affected test format strings to %+v.

Fixes https://github.com/GoogleCloudPlatform/netd/issues/515